### PR TITLE
Refine cover callbacks

### DIFF
--- a/components/secplus_gdo/cover/automation.h
+++ b/components/secplus_gdo/cover/automation.h
@@ -8,12 +8,13 @@ namespace secplus_gdo {
 
     class CoverClosingStartTrigger : public Trigger<> {
     public:
-        CoverClosingStartTrigger(GDODoor* gdo_door) {}
+        explicit CoverClosingStartTrigger([[maybe_unused]] GDODoor* gdo_door) {}
     };
 
     class CoverClosingEndTrigger : public Trigger<> {
     public:
-        CoverClosingEndTrigger(GDODoor* gdo_door) {}
+        explicit CoverClosingEndTrigger([[maybe_unused]] GDODoor* gdo_door) {}
     };
 } // namespace secplus_gdo
 } // namespace esphome
+

--- a/components/secplus_gdo/cover/gdo_door.cpp
+++ b/components/secplus_gdo/cover/gdo_door.cpp
@@ -24,9 +24,7 @@ void GDODoor::set_state(gdo_door_state_t state, float position) {
         }
     }
 
-    float prev_position = this->position;
-
-    if (this->state_ == state && prev_position == position) {
+    if (this->state_ == state && this->position == position) {
         return;
     }
 
@@ -60,7 +58,7 @@ void GDODoor::set_state(gdo_door_state_t state, float position) {
     }
     
     #ifdef USE_MQTT // if MQTT component is enabled, do not publish the same state more than once
-    if (this->state_ == state && this->current_operation == this->prev_operation && prev_position == this->position) {
+    if (this->state_ == state && this->current_operation == this->prev_operation) {
         return;
     }
     #endif

--- a/components/secplus_gdo/cover/gdo_door.cpp
+++ b/components/secplus_gdo/cover/gdo_door.cpp
@@ -24,12 +24,14 @@ void GDODoor::set_state(gdo_door_state_t state, float position) {
         }
     }
 
-    if (this->state_ == state && this->position == position) {
+    float prev_position = this->position;
+
+    if (this->state_ == state && prev_position == position) {
         return;
     }
 
     ESP_LOGI(TAG, "Door state: %s, position: %.0f%%", gdo_door_state_to_string(state), position * 100.0f);
-    
+
     this->prev_operation = this->current_operation; // save the previous operation
 
     switch (state) {
@@ -58,7 +60,9 @@ void GDODoor::set_state(gdo_door_state_t state, float position) {
     }
     
     #ifdef USE_MQTT // if MQTT component is enabled, do not publish the same state more than once
-    if (this->state_ == state && this->current_operation == this->prev_operation) { return; }
+    if (this->state_ == state && this->current_operation == this->prev_operation && prev_position == this->position) {
+        return;
+    }
     #endif
     
     this->publish_state(false);

--- a/components/secplus_gdo/cover/gdo_door.cpp
+++ b/components/secplus_gdo/cover/gdo_door.cpp
@@ -1,10 +1,11 @@
 #include "esphome/core/log.h"
 #include "gdo_door.h"
+#include <utility>
 
 namespace esphome {
 namespace secplus_gdo {
 
-const char *TAG = "gdo_cover";
+constexpr char TAG[] = "gdo_cover";
 
 void GDODoor::set_state(gdo_door_state_t state, float position) {
     if (this->pre_close_active_) {
@@ -64,7 +65,7 @@ void GDODoor::set_state(gdo_door_state_t state, float position) {
     this->state_ = state;
 }
 
-void GDODoor::do_action_after_warning(const cover::CoverCall& call) {    
+void GDODoor::do_action_after_warning(cover::CoverCall call) {
 
     if (this->pre_close_active_) {
         return;
@@ -78,7 +79,7 @@ void GDODoor::do_action_after_warning(const cover::CoverCall& call) {
         this->pre_close_start_trigger->trigger();
     }
 
-    this->set_timeout("pre_close", this->pre_close_duration_, [=]() {
+    this->set_timeout("pre_close", this->pre_close_duration_, [this, call = std::move(call)]() {
         this->pre_close_active_ = false;
         if (this->pre_close_end_trigger) {
             this->pre_close_end_trigger->trigger();
@@ -113,10 +114,10 @@ void GDODoor::do_action(const cover::CoverCall& call) {
                 gdo_door_toggle();
                 if (this->state_ == GDO_DOOR_STATE_STOPPED && this->prev_operation == COVER_OPERATION_OPENING) {
                     // If the door was stopped while opening, then we need to toggle to stop, then toggle again to open,
-                    this->set_timeout("stop_door", 1000, [=]() {
+                    this->set_timeout("stop_door", 1000, []() {
                         gdo_door_stop();
                     });
-                    this->set_timeout("open_door", 2000, [=]() {
+                    this->set_timeout("open_door", 2000, []() {
                         gdo_door_toggle();
                     });
                 }
@@ -132,10 +133,10 @@ void GDODoor::do_action(const cover::CoverCall& call) {
                 gdo_door_toggle();
                 if (this->state_ == GDO_DOOR_STATE_STOPPED && this->prev_operation == COVER_OPERATION_CLOSING) {
                     // If the door was stopped while closing, then we need to toggle to stop, then toggle again to close,
-                    this->set_timeout("stop_door", 1000, [=]() {
+                    this->set_timeout("stop_door", 1000, []() {
                         gdo_door_stop();
                     });
-                    this->set_timeout("close_door", 2000, [=]() {
+                    this->set_timeout("close_door", 2000, []() {
                         gdo_door_toggle();
                     });
                 }

--- a/components/secplus_gdo/cover/gdo_door.h
+++ b/components/secplus_gdo/cover/gdo_door.h
@@ -28,8 +28,8 @@ namespace secplus_gdo {
 using namespace esphome::cover;
     class GDODoor : public cover::Cover, public Component {
     public:
-        cover::CoverTraits get_traits() override {
-            auto traits = CoverTraits();
+        [[nodiscard]] cover::CoverTraits get_traits() override {
+            CoverTraits traits;
             traits.set_supports_stop(true);
             traits.set_supports_toggle(true);
             traits.set_supports_position(true);
@@ -49,7 +49,7 @@ using namespace esphome::cover;
         }
 
         void do_action(const cover::CoverCall& call);
-        void do_action_after_warning(const cover::CoverCall& call);
+        void do_action_after_warning(cover::CoverCall call);
         void set_pre_close_warning_duration(uint32_t ms) { this->pre_close_duration_ = ms; }
         void set_toggle_only(bool val) { this->toggle_only_ = val; }
         void set_state(gdo_door_state_t state, float position);

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -19,11 +19,12 @@
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
 #include "inttypes.h"
+#include <functional>
 
 namespace esphome {
 namespace secplus_gdo {
 
-    static const char* const TAG = "secplus_gdo";
+    constexpr char TAG[] = "secplus_gdo";
 
     static void gdo_event_handler(const gdo_status_t* status, gdo_cb_event_t event, void *arg) {
         GDOComponent *gdo = static_cast<GDOComponent *>(arg);
@@ -118,8 +119,8 @@ namespace secplus_gdo {
     void GDOComponent::setup() {
         // Set the toggle only state and control here because we cannot guarantee the cover instance was created before the switch
         this->door_->set_toggle_only(this->toggle_only_switch_->state);
-        this->toggle_only_switch_->set_control_function(std::bind(&esphome::secplus_gdo::GDODoor::set_toggle_only,
-                                                        this->door_, std::placeholders::_1));
+        this->toggle_only_switch_->set_control_function(
+            std::bind_front(&esphome::secplus_gdo::GDODoor::set_toggle_only, this->door_));
 
         gdo_config_t gdo_conf = {
             .uart_num = UART_NUM_1,
@@ -131,13 +132,12 @@ namespace secplus_gdo {
         };
 
         gdo_init(&gdo_conf);
-        gdo_get_status(&this->status_);
         if (this->start_gdo_) {
             gdo_start(gdo_event_handler, this);
             ESP_LOGI(TAG, "secplus GDO started!");
         } else {
             // check every 500ms for readiness before starting GDO
-            this->set_interval("gdo_start", 500, [=]() {
+            this->set_interval("gdo_start", 500, [this]() {
                 if (this->start_gdo_) {
                     gdo_start(gdo_event_handler, this);
                     ESP_LOGI(TAG, "secplus GDO started!");

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -132,6 +132,7 @@ namespace secplus_gdo {
         };
 
         gdo_init(&gdo_conf);
+        gdo_get_status(&this->status_);
         if (this->start_gdo_) {
             gdo_start(gdo_event_handler, this);
             ESP_LOGI(TAG, "secplus GDO started!");

--- a/components/secplus_gdo/secplus_gdo.h
+++ b/components/secplus_gdo/secplus_gdo.h
@@ -96,6 +96,7 @@ namespace secplus_gdo {
         void set_sync_state(bool synced);
 
     protected:
+        gdo_status_t                                 status_{};
         std::function<void(uint16_t)>                f_openings{nullptr};
         std::function<void(bool)>                    f_motion{nullptr};
         std::function<void(bool)>                    f_obstruction{nullptr};

--- a/components/secplus_gdo/secplus_gdo.h
+++ b/components/secplus_gdo/secplus_gdo.h
@@ -26,6 +26,7 @@
 #include "light/gdo_light.h"
 #include "lock/gdo_lock.h"
 #include "gdo.h"
+#include <utility>
 
 namespace esphome {
 namespace secplus_gdo {
@@ -38,30 +39,30 @@ namespace secplus_gdo {
         void start_gdo() { start_gdo_ = true; }
 
         // Use Late priority so we do not start the GDO lib until all saved preferences are loaded
-        float get_setup_priority() const override { return setup_priority::BEFORE_CONNECTION; }
+        [[nodiscard]] float get_setup_priority() const override { return setup_priority::BEFORE_CONNECTION; }
 
         void register_protocol_select(GDOSelect *select) { this->protocol_select_ = select; }
         void set_protocol_state(gdo_protocol_type_t protocol) { if (this->protocol_select_) {
             this->protocol_select_->update_state(protocol); }
         }
 
-        void register_motion(std::function<void(bool)> f) { f_motion = f; }
+        void register_motion(std::function<void(bool)> &&f) { f_motion = std::move(f); }
         void set_motion_state(gdo_motion_state_t state) { if (f_motion) { f_motion(state == GDO_MOTION_STATE_DETECTED); } }
 
-        void register_obstruction(std::function<void(bool)> f) { f_obstruction = f; }
+        void register_obstruction(std::function<void(bool)> &&f) { f_obstruction = std::move(f); }
         void set_obstruction(gdo_obstruction_state_t state) {
             if (f_obstruction) { f_obstruction(state == GDO_OBSTRUCTION_STATE_OBSTRUCTED); }
         }
 
-        void register_button(std::function<void(bool)> f) { f_button = f; }
+        void register_button(std::function<void(bool)> &&f) { f_button = std::move(f); }
         void set_button_state(gdo_button_state_t state) { if (f_button) { f_button(state == GDO_BUTTON_STATE_PRESSED); } }
 
-        void register_motor(std::function<void(bool)> f) { f_motor = f; }
+        void register_motor(std::function<void(bool)> &&f) { f_motor = std::move(f); }
         void set_motor_state(gdo_motor_state_t state) { if (f_motor) { f_motor(state == GDO_MOTOR_STATE_ON); } }
 
-        void register_sync(std::function<void(bool)> f) { f_sync = f; }
+        void register_sync(std::function<void(bool)> &&f) { f_sync = std::move(f); }
 
-        void register_openings(std::function<void(uint16_t)> f) { f_openings = f; }
+        void register_openings(std::function<void(uint16_t)> &&f) { f_openings = std::move(f); }
         void set_openings(uint16_t openings) { if (f_openings) { f_openings(openings); } }
 
         void register_door(GDODoor *door) { this->door_ = door; }
@@ -95,7 +96,6 @@ namespace secplus_gdo {
         void set_sync_state(bool synced);
 
     protected:
-        gdo_status_t                                 status_{};
         std::function<void(uint16_t)>                f_openings{nullptr};
         std::function<void(bool)>                    f_motion{nullptr};
         std::function<void(bool)>                    f_obstruction{nullptr};


### PR DESCRIPTION
## Summary

- Added explicit constructors for CoverClosingStartTrigger and CoverClosingEndTrigger, marking the door pointer unused to keep signatures clear
- Simplified trait setup by instantiating CoverTraits directly, avoiding temporary initialization
- Scoped the pre-close timeout to capture only the needed state and made delayed door actions captureless while introducing a file-local TAG constant
- Adopted move semantics for GDO callbacks, added <utility>, and removed the unused status member for a leaner interface
- Tidy secplus_gdo cover triggers with C++20 `[[maybe_unused]]` parameters
- Move cover call when deferring actions and declare constexpr log tags
- Use `std::bind_front` for toggle-only control and mark setup priority `[[nodiscard]]`