### PR TITLE
Feature: add remote button tracking for secplus_gdo

### DIFF
--- a/circuitsetup-secplus-garage-door-opener.yaml
+++ b/circuitsetup-secplus-garage-door-opener.yaml
@@ -61,6 +61,9 @@ substitutions:
   garage_obstruction_name: Obstruction
   garage_motor_name: Motor
   garage_button_name: Wall Button
+  garage_remote_1_name: Remote 1
+  garage_remote_2_name: Remote 2
+  garage_remote_3_name: Remote 3
   garage_sync_name: Synced
   temp_update_interval: 60s
   temp_adjust: "0.8825" # 1-0.1175 - 11.75% decrease

--- a/components/secplus_gdo/binary_sensor/__init__.py
+++ b/components/secplus_gdo/binary_sensor/__init__.py
@@ -31,12 +31,14 @@ GDOBinarySensor = secplus_gdo_ns.class_(
 )
 
 CONF_TYPE = "type"
+CONF_REMOTE = "remote"
 TYPES = {
     "motion": "register_motion",
     "obstruction": "register_obstruction",
     "motor": "register_motor",
     "button": "register_button",
     "sync": "register_sync",
+    "remote_button": "register_remote_button",
 }
 
 
@@ -45,6 +47,7 @@ CONFIG_SCHEMA = (
     .extend(
         {
             cv.Required(CONF_TYPE): cv.enum(TYPES, lower=True),
+            cv.Optional(CONF_REMOTE): cv.int_range(1, 3),
         }
     )
     .extend(SECPLUS_GDO_CONFIG_SCHEMA)
@@ -56,6 +59,12 @@ async def to_code(config):
     await binary_sensor.register_binary_sensor(var, config)
     await cg.register_component(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
-    fcall = str(parent) + "->" + str(TYPES[config[CONF_TYPE]])
-    text = fcall + "(std::bind(&" + str(GDOBinarySensor) + "::publish_state," + str(config[CONF_ID]) + ",std::placeholders::_1))"
-    cg.add((cg.RawExpression(text)))
+    if config[CONF_TYPE] == "remote_button":
+        remote = config[CONF_REMOTE]
+        text = (
+            f"{parent}->register_remote_button({remote}, std::bind(&{GDOBinarySensor}::publish_state,{config[CONF_ID]},std::placeholders::_1))"
+        )
+    else:
+        fcall = str(parent) + "->" + str(TYPES[config[CONF_TYPE]])
+        text = fcall + "(std::bind(&" + str(GDOBinarySensor) + "::publish_state," + str(config[CONF_ID]) + ",std::placeholders::_1))"
+    cg.add(cg.RawExpression(text))

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -82,8 +82,12 @@ namespace secplus_gdo {
             ESP_LOGI(TAG, "Battery: %s", gdo_battery_state_to_string(status->battery));
             break;
         case GDO_CB_EVENT_BUTTON:
-            ESP_LOGI(TAG, "Button: %s", gdo_button_state_to_string(status->button));
-            gdo->set_button_state(status->button);
+            ESP_LOGI(TAG, "Button: %s remote: %" PRIu32, gdo_button_state_to_string(status->button), status->remote_id);
+            if (status->remote_id != 0) {
+                gdo->set_remote_button_state(status->remote_id, status->button);
+            } else {
+                gdo->set_button_state(status->button);
+            }
             break;
         case GDO_CB_EVENT_MOTOR:
             ESP_LOGI(TAG, "Motor: %s", gdo_motor_state_to_string(status->motor));
@@ -168,6 +172,24 @@ namespace secplus_gdo {
 
         if (this->f_sync) {
             this->f_sync(synced);
+        }
+    }
+
+    void GDOComponent::set_remote_button_state(uint32_t remote_id, gdo_button_state_t state) {
+        if (remote_id == 0) {
+            return;
+        }
+        for (size_t i = 0; i < this->f_remote_buttons_.size(); i++) {
+            if (this->remote_ids_[i] == 0) {
+                this->remote_ids_[i] = remote_id;
+            }
+            if (this->remote_ids_[i] == remote_id) {
+                auto &cb = this->f_remote_buttons_[i];
+                if (cb) {
+                    cb(state == GDO_BUTTON_STATE_PRESSED);
+                }
+                break;
+            }
         }
     }
 

--- a/components/secplus_gdo/secplus_gdo.h
+++ b/components/secplus_gdo/secplus_gdo.h
@@ -27,6 +27,7 @@
 #include "lock/gdo_lock.h"
 #include "gdo.h"
 #include <utility>
+#include <array>
 
 namespace esphome {
 namespace secplus_gdo {
@@ -56,6 +57,13 @@ namespace secplus_gdo {
 
         void register_button(std::function<void(bool)> &&f) { f_button = std::move(f); }
         void set_button_state(gdo_button_state_t state) { if (f_button) { f_button(state == GDO_BUTTON_STATE_PRESSED); } }
+
+        void register_remote_button(uint8_t slot, std::function<void(bool)> &&f) {
+            if (slot >= 1 && slot <= 3) {
+                f_remote_buttons_[slot - 1] = std::move(f);
+            }
+        }
+        void set_remote_button_state(uint32_t remote_id, gdo_button_state_t state);
 
         void register_motor(std::function<void(bool)> &&f) { f_motor = std::move(f); }
         void set_motor_state(gdo_motor_state_t state) { if (f_motor) { f_motor(state == GDO_MOTOR_STATE_ON); } }
@@ -103,6 +111,8 @@ namespace secplus_gdo {
         std::function<void(bool)>                    f_button{nullptr};
         std::function<void(bool)>                    f_motor{nullptr};
         std::function<void(bool)>                    f_sync{nullptr};
+        std::array<std::function<void(bool)>,3>      f_remote_buttons_{};
+        std::array<uint32_t,3>                       remote_ids_{};
         GDODoor*                                     door_{nullptr};
         GDOLight*                                    light_{nullptr};
         GDOLock*                                     lock_{nullptr};

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -67,6 +67,24 @@ binary_sensor:
     secplus_gdo_id: cs_gdo
     type: button
   - platform: secplus_gdo
+    name: $garage_remote_1_name
+    id: gdo_remote_1
+    secplus_gdo_id: cs_gdo
+    type: remote_button
+    remote: 1
+  - platform: secplus_gdo
+    name: $garage_remote_2_name
+    id: gdo_remote_2
+    secplus_gdo_id: cs_gdo
+    type: remote_button
+    remote: 2
+  - platform: secplus_gdo
+    name: $garage_remote_3_name
+    id: gdo_remote_3
+    secplus_gdo_id: cs_gdo
+    type: remote_button
+    remote: 3
+  - platform: secplus_gdo
     name: $garage_sync_name
     id: gdo_synced
     secplus_gdo_id: cs_gdo


### PR DESCRIPTION
## Summary
- track up to three Security+ remotes individually
- expose configuration to name each remote button sensor
- surface remote button states via YAML package examples