### PR TITLE
Add wireless remote binary sensor

### DIFF
--- a/circuitsetup-secplus-garage-door-opener.yaml
+++ b/circuitsetup-secplus-garage-door-opener.yaml
@@ -61,6 +61,7 @@ substitutions:
   garage_obstruction_name: Obstruction
   garage_motor_name: Motor
   garage_button_name: Wall Button
+  garage_wireless_remote_name: Wireless Remote
   garage_sync_name: Synced
   garage_battery_name: Battery
   temp_update_interval: 60s

--- a/components/secplus_gdo/README.md
+++ b/components/secplus_gdo/README.md
@@ -42,3 +42,15 @@ cover:
 * **pre_close_warning_start** (_Optional_, Action): Action(s) to execute the pre-close warning
 * **pre_close_warning_end** (_Optional_, Action): Action(s) to execute when the pre-close warning stops
 * **toggle_only** (_Optional_, boolean)_: When true, all open/close commands are sent as a toggle door actions to the garage opener. This is a compatibility fix for some openers, such as some Merlin brand openers that are known to only respond to toggle commands and don't respond to discrete open/close commands.
+
+### Binary Sensors
+
+```yaml
+binary_sensor:
+  - platform: secplus_gdo
+    type: wireless_remote
+    secplus_gdo_id: cs_gdo
+    name: Wireless Remote
+```
+
+* **type** (**Required**, string): Sensor type. Use `wireless_remote` to detect when the door is triggered by a wireless remote.

--- a/components/secplus_gdo/binary_sensor/__init__.py
+++ b/components/secplus_gdo/binary_sensor/__init__.py
@@ -37,6 +37,7 @@ TYPES = {
     "motor": "register_motor",
     "button": "register_button",
     "sync": "register_sync",
+    "wireless_remote": "register_wireless_remote",
 }
 
 
@@ -59,3 +60,4 @@ async def to_code(config):
     fcall = str(parent) + "->" + str(TYPES[config[CONF_TYPE]])
     text = fcall + "(std::bind(&" + str(GDOBinarySensor) + "::publish_state," + str(config[CONF_ID]) + ",std::placeholders::_1))"
     cg.add((cg.RawExpression(text)))
+

--- a/components/secplus_gdo/cover/gdo_door.cpp
+++ b/components/secplus_gdo/cover/gdo_door.cpp
@@ -1,6 +1,6 @@
 #include "esphome/core/log.h"
 #include "gdo_door.h"
-#include "secplus_gdo.h"
+#include "../secplus_gdo.h"
 #include <utility>
 
 namespace esphome {

--- a/components/secplus_gdo/cover/gdo_door.cpp
+++ b/components/secplus_gdo/cover/gdo_door.cpp
@@ -1,5 +1,6 @@
 #include "esphome/core/log.h"
 #include "gdo_door.h"
+#include "secplus_gdo.h"
 #include <utility>
 
 namespace esphome {
@@ -93,6 +94,10 @@ void GDODoor::do_action_after_warning(cover::CoverCall call) {
 }
 
 void GDODoor::do_action(const cover::CoverCall& call) {
+    if (this->parent_) {
+        this->parent_->notify_cover_command();
+    }
+
     if (call.get_stop()) {
         ESP_LOGD(TAG, "Sending STOP action");
         gdo_door_stop();

--- a/components/secplus_gdo/cover/gdo_door.h
+++ b/components/secplus_gdo/cover/gdo_door.h
@@ -25,6 +25,8 @@
 namespace esphome {
 namespace secplus_gdo {
 
+class GDOComponent;
+
 using namespace esphome::cover;
     class GDODoor : public cover::Cover, public Component {
     public:
@@ -53,6 +55,7 @@ using namespace esphome::cover;
         void set_pre_close_warning_duration(uint32_t ms) { this->pre_close_duration_ = ms; }
         void set_toggle_only(bool val) { this->toggle_only_ = val; }
         void set_state(gdo_door_state_t state, float position);
+        void set_parent(GDOComponent *parent) { this->parent_ = parent; }
 
     protected:
         void control(const cover::CoverCall& call);
@@ -66,6 +69,7 @@ using namespace esphome::cover;
         CoverOperation           prev_operation{COVER_OPERATION_IDLE};
         gdo_door_state_t         state_{GDO_DOOR_STATE_UNKNOWN};
         bool                     synced_{false};
+        GDOComponent            *parent_{nullptr};
     };
 } // namespace secplus_gdo
 } // namespace esphome

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -75,6 +75,11 @@ binary_sensor:
     secplus_gdo_id: cs_gdo
     type: button
   - platform: secplus_gdo
+    name: $garage_wireless_remote_name
+    id: gdo_wireless_remote
+    secplus_gdo_id: cs_gdo
+    type: wireless_remote
+  - platform: secplus_gdo
     name: $garage_sync_name
     id: gdo_synced
     secplus_gdo_id: cs_gdo

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -79,6 +79,7 @@ binary_sensor:
     id: gdo_wireless_remote
     secplus_gdo_id: cs_gdo
     type: wireless_remote
+    icon: mdi:remote
   - platform: secplus_gdo
     name: $garage_sync_name
     id: gdo_synced


### PR DESCRIPTION
## Summary
- detect wireless remotes by monitoring motor state when neither wall button nor cover triggered
- expose new `wireless_remote` binary sensor and document usage
- include wireless remote sensor in example configs