### PR TITLE
secplus_gdo ESPHome hardening & paired device counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /secrets.yaml
 __pycache__/
 .vscode
-*.code-workspace
+circuitsetup-esphome.code-workspace
+debug.log

--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@ This repository builds on the original garage door opener work from [Konnected I
 
 ## Choose a Starting Point
 
-Use the repo in one of these three ways:
+Use CircuitSetup garage door firmware in one of these four ways:
 
-1. [`circuitsetup-gdo-default.yaml`](circuitsetup-gdo-default.yaml)
+1. [CircuitSetup ESP Web Installer](https://circuitsetup.github.io/ESPWebInstaller/)
+   The quickest path if you want pre-compiled firmware and browser-based flashing.
+2. [`circuitsetup-gdo-default.yaml`](circuitsetup-gdo-default.yaml)
    The simplest starter/import path for CircuitSetup Security+ hardware.
-2. [`circuitsetup-secplus-garage-door-opener.yaml`](circuitsetup-secplus-garage-door-opener.yaml)
+3. [`circuitsetup-secplus-garage-door-opener.yaml`](circuitsetup-secplus-garage-door-opener.yaml)
    The full editable reference config for the Security+ opener.
-3. [`components/secplus_gdo/README.md`](components/secplus_gdo/README.md)
+4. [`components/secplus_gdo/README.md`](components/secplus_gdo/README.md)
    The advanced path for direct `external_components` usage and fully custom YAML.
 
 For most users, start with the default or full Security+ YAML and only edit the documented substitutions near the top of the file.

--- a/README.md
+++ b/README.md
@@ -2,20 +2,58 @@
 
 ESPHome configurations and a custom `secplus_gdo` external component for CircuitSetup garage door opener hardware.
 
+## Choose a Starting Point
+
+Use the repo in one of these three ways:
+
+1. [`circuitsetup-gdo-default.yaml`](circuitsetup-gdo-default.yaml)
+   The simplest starter/import path for CircuitSetup Security+ hardware.
+2. [`circuitsetup-secplus-garage-door-opener.yaml`](circuitsetup-secplus-garage-door-opener.yaml)
+   The full editable reference config for the Security+ opener.
+3. [`components/secplus_gdo/README.md`](components/secplus_gdo/README.md)
+   The advanced path for direct `external_components` usage and fully custom YAML.
+
+For most users, start with the default or full Security+ YAML and only edit the documented substitutions near the top of the file.
+
 ## Quick Start
 
-For CircuitSetup Security+ hardware, the simplest starting point is:
+For CircuitSetup Security+ hardware, the quickest starting point is:
 
 ```yaml
 packages:
-  circuitsetup.secplus-garage-door-opener: github://CircuitSetup/circuitsetup-esphome/circuitsetup-secplus-garage-door-opener.yaml@master
+  circuitsetup.secplus-garage-door-opener: github://CircuitSetup/circuitsetup-esphome/circuitsetup-gdo-default.yaml@master
 ```
 
-That package targets ESPHome `2026.2.0+`, imports the `secplus_gdo` component, and includes the standard light, cover, lock, warning, Wi-Fi, and diagnostics setup from a pinned release tag instead of a floating branch.
+That starter file pulls in the full Security+ package bundle, while the package bundle itself stays pinned to a tested release tag.
 
-## Security Notes
+## Common Customizations
 
-For Home Assistant 2026.2+ deployments, the examples in this repo now document the recommended secrets-based security settings:
+The full Security+ YAML now has a supported "safe customization surface" near the top of the file. Most users should only need to edit:
+
+- Device name and friendly name
+- `garage_label`, which renames the common Garage Door / Garage Light / Garage Openings / Garage Temp / Garage Humidity entities together
+- Close-warning duration
+- Temperature update interval and sensor offsets
+- Logger level
+- Wi-Fi response tuning
+
+Example:
+
+```yaml
+substitutions:
+  name: shop-gdo
+  friendly_name: Shop Door Opener
+  garage_label: Shop
+  garage_door_close_warning_duration: 8s
+  temp_update_interval: 30s
+  logger_level: INFO
+  wifi_power_save_mode: NONE
+  wifi_post_connect_roaming: "false"
+```
+
+## Security Settings
+
+For Home Assistant 2026.2+ deployments, the shipped YAML documents the recommended secrets-based security settings:
 
 ```yaml
 api:
@@ -27,8 +65,20 @@ ota:
     password: !secret ota_password
 ```
 
+## When You Need Local YAML Edits
+
+Use the full Security+ YAML for common name, timing, logger, and Wi-Fi changes.
+
+Switch to a local copy of the full YAML when you want to:
+
+- Remove or replace packages such as `temp-sensor.yaml`
+- Change package internals instead of top-level substitutions
+- Edit the custom `secplus_gdo` component locally
+
+Remote package composition works well for normal setup, but it is not the best fit for deep feature toggles. For those cases, use a local checkout and the local `external_components` / local package workflow documented in [`components/secplus_gdo/README.md`](components/secplus_gdo/README.md).
+
 ## Advanced Usage
 
-If you want to use the external component directly instead of the full package bundle, see [components/secplus_gdo/README.md](components/secplus_gdo/README.md).
+If you want to use the external component directly instead of the full package bundle, see [`components/secplus_gdo/README.md`](components/secplus_gdo/README.md).
 
 The component now starts itself during setup, so custom configs no longer need a hidden `wifi.on_connect` hook to call `id(cs_gdo).start_gdo()`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For CircuitSetup Security+ hardware, the simplest starting point is:
 
 ```yaml
 packages:
-  circuitsetup.secplus-garage-door-opener: github://CircuitSetup/circuitsetup-esphome/circuitsetup-secplus-garage-door-opener.yaml@circuitsetup-secplus-garage-door-opener-v1.4.5-esphome-v2026.2.4
+  circuitsetup.secplus-garage-door-opener: github://CircuitSetup/circuitsetup-esphome/circuitsetup-secplus-garage-door-opener.yaml@master
 ```
 
 That package targets ESPHome `2026.2.0+`, imports the `secplus_gdo` component, and includes the standard light, cover, lock, warning, Wi-Fi, and diagnostics setup from a pinned release tag instead of a floating branch.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CircuitSetup ESPHome
 
 ESPHome configurations and a custom `secplus_gdo` external component for CircuitSetup garage door opener hardware.
+This repository builds on the original garage door opener work from [Konnected Inc.](https://github.com/konnected-io/konnected-esphome), whose earlier ESPHome support helped establish the foundation for this project.
 
 ## Choose a Starting Point
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
+# CircuitSetup ESPHome
 
+ESPHome configurations and a custom `secplus_gdo` external component for CircuitSetup garage door opener hardware.
+
+## Quick Start
+
+For CircuitSetup Security+ hardware, the simplest starting point is:
+
+```yaml
+packages:
+  circuitsetup.secplus-garage-door-opener: github://CircuitSetup/circuitsetup-esphome/circuitsetup-secplus-garage-door-opener.yaml@circuitsetup-secplus-garage-door-opener-v1.4.5-esphome-v2026.2.4
+```
+
+That package targets ESPHome `2026.2.0+`, imports the `secplus_gdo` component, and includes the standard light, cover, lock, warning, Wi-Fi, and diagnostics setup from a pinned release tag instead of a floating branch.
+
+## Security Notes
+
+For Home Assistant 2026.2+ deployments, the examples in this repo now document the recommended secrets-based security settings:
+
+```yaml
+api:
+  encryption:
+    key: !secret api_encryption_key
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+```
+
+## Advanced Usage
+
+If you want to use the external component directly instead of the full package bundle, see [components/secplus_gdo/README.md](components/secplus_gdo/README.md).
+
+The component now starts itself during setup, so custom configs no longer need a hidden `wifi.on_connect` hook to call `id(cs_gdo).start_gdo()`.

--- a/circuitsetup-gdo-default.yaml
+++ b/circuitsetup-gdo-default.yaml
@@ -1,2 +1,10 @@
+# CircuitSetup Security+ Garage Door Opener starter import.
+#
+# Use this file when you want the quickest setup path in ESPHome Dashboard.
+# For common customizations such as entity names, warning timing, logger level,
+# or Wi-Fi behavior, open `circuitsetup-secplus-garage-door-opener.yaml`.
+# For package-level or component-level customization, use a local checkout of
+# this repo instead of editing the remote package import.
+
 packages:
   circuitsetup.secplus-garage-door-opener: github://CircuitSetup/circuitsetup-esphome/circuitsetup-secplus-garage-door-opener.yaml@master

--- a/circuitsetup-gdo-dry-contact.yaml
+++ b/circuitsetup-gdo-dry-contact.yaml
@@ -50,7 +50,7 @@ substitutions:
   name: circuitsetup-gdo
   friendly_name: Garage Door Opener
   project_name: circuitsetup.gdo-dry-contact
-  project_version: "1.0"
+  project_version: "1.1"
   garage_door_cover_name: Garage Door
   garage_temp_name: Garage Temp
   garage_humidity_name: Garage Humidity

--- a/circuitsetup-gdo-dry-contact.yaml
+++ b/circuitsetup-gdo-dry-contact.yaml
@@ -92,7 +92,7 @@ packages:
 
   remote_package:
     url: https://github.com/circuitsetup/circuitsetup-esphome
-    ref: circuitsetup-gdo-dry-contact-v1.0-esphome-v2026.2.4
+    ref: master
     refresh: 1d
     files:
 
@@ -155,7 +155,7 @@ packages:
 # Enables automatic discovery and upgrades via ESPHome Dashboard
 # more: https://esphome.io/guides/getting_started_hassio.html
 dashboard_import:
-  package_import_url: github://CircuitSetup/circuitsetup-esphome/circuitsetup-gdo-dry-contact.yaml@circuitsetup-gdo-dry-contact-v1.0-esphome-v2026.2.4
+  package_import_url: github://CircuitSetup/circuitsetup-esphome/circuitsetup-gdo-dry-contact.yaml@master
   import_full_config: false
 
 #### 

--- a/circuitsetup-gdo-dry-contact.yaml
+++ b/circuitsetup-gdo-dry-contact.yaml
@@ -92,7 +92,7 @@ packages:
 
   remote_package:
     url: https://github.com/circuitsetup/circuitsetup-esphome
-    ref: master
+    ref: circuitsetup-gdo-dry-contact-v1.0-esphome-v2026.2.4
     refresh: 1d
     files:
 
@@ -155,7 +155,7 @@ packages:
 # Enables automatic discovery and upgrades via ESPHome Dashboard
 # more: https://esphome.io/guides/getting_started_hassio.html
 dashboard_import:
-  package_import_url: github://CircuitSetup/circuitsetup-esphome/circuitsetup-gdo-dry-contact.yaml@master
+  package_import_url: github://CircuitSetup/circuitsetup-esphome/circuitsetup-gdo-dry-contact.yaml@circuitsetup-gdo-dry-contact-v1.0-esphome-v2026.2.4
   import_full_config: false
 
 #### 
@@ -174,6 +174,9 @@ logger:
 # Enables the native ESPHome API
 # more: https://esphome.io/components/api.html
 api:
+  # Recommended for Home Assistant 2026.2+:
+  # encryption:
+  #   key: !secret api_encryption_key
 
 esp32_improv:
   authorizer: none

--- a/circuitsetup-secplus-garage-door-opener.yaml
+++ b/circuitsetup-secplus-garage-door-opener.yaml
@@ -63,7 +63,7 @@ substitutions:
   garage_button_name: Wall Button
   garage_wireless_remote_name: Wireless Remote
   garage_sync_name: Synced
-  garage_battery_name: Battery
+  garage_battery_name: Battery #only used on certain GDO models with battery backups
   temp_update_interval: 60s
   temp_adjust: "0.8825" # 1-0.1175 - 11.75% decrease
   dew_point_offset: "1.3" # Offset in °F to correct sensor's lower dew point reading
@@ -93,7 +93,7 @@ substitutions:
   scl: GPIO15
 
 external_components:
-  - source: github://CircuitSetup/circuitsetup-esphome@circuitsetup-secplus-garage-door-opener-v1.4.5-esphome-v2026.2.4
+  - source: github://CircuitSetup/circuitsetup-esphome@master
     components: [ secplus_gdo ]
 
   # Un-comment below and comment above for local modification
@@ -110,7 +110,7 @@ packages:
 
   remote_package:
     url: https://github.com/CircuitSetup/circuitsetup-esphome
-    ref: circuitsetup-secplus-garage-door-opener-v1.4.5-esphome-v2026.2.4
+    ref: master
     refresh: 1d
     files:
 
@@ -160,7 +160,7 @@ packages:
 # Enables automatic discovery and upgrades via ESPHome Dashboard
 # more: https://esphome.io/guides/getting_started_hassio.html
 dashboard_import:
-  package_import_url: github://CircuitSetup/circuitsetup-esphome/circuitsetup-secplus-garage-door-opener.yaml@circuitsetup-secplus-garage-door-opener-v1.4.5-esphome-v2026.2.4
+  package_import_url: github://CircuitSetup/circuitsetup-esphome/circuitsetup-secplus-garage-door-opener.yaml@master
   import_full_config: false
 
 ####

--- a/circuitsetup-secplus-garage-door-opener.yaml
+++ b/circuitsetup-secplus-garage-door-opener.yaml
@@ -192,5 +192,3 @@ esphome:
   platformio_options:
     lib_deps:
       - https://github.com/CircuitSetup/gdolib
-    build_flags:
-      - -Wl,--wrap=esp_panic_handler

--- a/circuitsetup-secplus-garage-door-opener.yaml
+++ b/circuitsetup-secplus-garage-door-opener.yaml
@@ -93,7 +93,7 @@ substitutions:
   scl: GPIO15
 
 external_components:
-  - source: github://CircuitSetup/circuitsetup-esphome@master
+  - source: github://CircuitSetup/circuitsetup-esphome@circuitsetup-secplus-garage-door-opener-v1.4.5-esphome-v2026.2.4
     components: [ secplus_gdo ]
 
   # Un-comment below and comment above for local modification
@@ -110,7 +110,7 @@ packages:
 
   remote_package:
     url: https://github.com/CircuitSetup/circuitsetup-esphome
-    ref: master
+    ref: circuitsetup-secplus-garage-door-opener-v1.4.5-esphome-v2026.2.4
     refresh: 1d
     files:
 
@@ -160,7 +160,7 @@ packages:
 # Enables automatic discovery and upgrades via ESPHome Dashboard
 # more: https://esphome.io/guides/getting_started_hassio.html
 dashboard_import:
-  package_import_url: github://CircuitSetup/circuitsetup-esphome/circuitsetup-secplus-garage-door-opener.yaml@master
+  package_import_url: github://CircuitSetup/circuitsetup-esphome/circuitsetup-secplus-garage-door-opener.yaml@circuitsetup-secplus-garage-door-opener-v1.4.5-esphome-v2026.2.4
   import_full_config: false
 
 ####
@@ -191,6 +191,9 @@ logger:
 # Enables the native ESPHome API
 # more: https://esphome.io/components/api.html
 api:
+  # Recommended for Home Assistant 2026.2+:
+  # encryption:
+  #   key: !secret api_encryption_key
 
 web_server:
 

--- a/circuitsetup-secplus-garage-door-opener.yaml
+++ b/circuitsetup-secplus-garage-door-opener.yaml
@@ -50,7 +50,7 @@ substitutions:
   name: circuitsetup-gdo
   friendly_name: Garage Door Opener
   project_name: circuitsetup.secplus-garage-door-opener
-  project_version: "1.4.5"
+  project_version: "1.5"
   garage_door_cover_name: Garage Door
   garage_light_name: Garage Light
   garage_openings_name: Garage Openings

--- a/circuitsetup-secplus-garage-door-opener.yaml
+++ b/circuitsetup-secplus-garage-door-opener.yaml
@@ -170,21 +170,12 @@ logger:
   hardware_uart: UART0     # force CP2102N/TTL header
   baud_rate: 115200
   deassert_rts_dtr: true   # avoids missing boot logs on auto-reset boards
-  level: VERBOSE
+  level: DEBUG
   logs:
-    esp-idf: DEBUG
-    api: DEBUG
-    api.service: DEBUG
-    esp32_ble: DEBUG
-    esp32_ble_server: DEBUG
-    scheduler: DEBUG
-    esp32.preferences: DEBUG
-    sensor.filter: DEBUG
-    rtttl: DEBUG
-    cover: DEBUG
-    sensor: DEBUG
     ledc.output: INFO
+    sensor: INFO
     json: INFO
+    api: DEBUG
 
 ####
 # NATIVE API

--- a/components/secplus_gdo/README.md
+++ b/components/secplus_gdo/README.md
@@ -2,6 +2,18 @@
 
 ESPHome `2026.2.0+` custom component for Security+ garage door openers.
 
+## When To Use This Path
+
+Use the full package YAML if you want the standard CircuitSetup hardware experience.
+
+Use the direct `secplus_gdo` component path when you want to:
+
+- Build a custom YAML from scratch
+- Use the component on a non-standard config
+- Edit the component locally during development
+
+The component starts automatically during setup. You do not need a separate `wifi.on_connect` automation to call `id(cs_gdo).start_gdo()`.
+
 ## Minimal Working Example
 
 ```yaml
@@ -42,9 +54,21 @@ binary_sensor:
     secplus_gdo_id: cs_gdo
 ```
 
-The component now starts automatically during setup. You do not need a separate `wifi.on_connect` automation to call `id(cs_gdo).start_gdo()`.
+## Local Development Workflow
 
-## Entity Types
+For local component edits, point `external_components` at the repo checkout instead of GitHub:
+
+```yaml
+external_components:
+  - source:
+      type: local
+      path: components
+    components: [secplus_gdo]
+```
+
+If you also need to edit package files such as `packages/secplus-gdo.yaml` or `packages/wifi-esp32.yaml`, use a local copy of the full top-level YAML instead of the remote package import.
+
+## Supported Entity Types
 
 `binary_sensor` types:
 - `motion`
@@ -77,13 +101,27 @@ The component now starts automatically during setup. You do not need a separate 
 
 ## Cover Options
 
-- `secplus_gdo_id`: required parent component ID.
-- `pre_close_warning_duration`: optional warning delay before close commands.
-- `pre_close_warning_start`: optional automation that runs when the warning starts.
-- `pre_close_warning_end`: optional automation that runs when the warning ends or is cancelled.
+- `secplus_gdo_id`: required parent component ID
+- `pre_close_warning_duration`: optional warning delay before close commands
+- `pre_close_warning_start`: optional automation that runs when the warning starts
+- `pre_close_warning_end`: optional automation that runs when the warning ends or is cancelled
 
 `toggle_only` behavior is still supported through the dedicated `switch` entity. That mode is useful for openers that only accept toggle commands instead of discrete open/close commands.
 
+## Reserved IDs
+
+The component validates generated ESPHome IDs against gdolib symbol names so generated C++ does not collide with the library.
+
+Do not reuse IDs such as:
+
+- `gdo_lock`
+- `gdo_start`
+- `gdo_sync`
+- `gdo_set_rolling_code`
+- `gdo_light_on`
+
+If config validation reports a reserved ID, rename the ESPHome `id` to something project-specific such as `garage_lock_entity`, `shop_gdo_light`, or `cs_gdo`.
+
 ## Full Package Example
 
-For the complete CircuitSetup hardware package, see [packages/secplus-gdo.yaml](https://github.com/CircuitSetup/circuitsetup-esphome/blob/master/packages/secplus-gdo.yaml).
+For the complete CircuitSetup hardware package, see [`packages/secplus-gdo.yaml`](https://github.com/CircuitSetup/circuitsetup-esphome/blob/master/packages/secplus-gdo.yaml).

--- a/components/secplus_gdo/README.md
+++ b/components/secplus_gdo/README.md
@@ -1,56 +1,89 @@
 # secplus_gdo
 
-## Documentation and Example Usage
+ESPHome `2026.2.0+` custom component for Security+ garage door openers.
 
-See [packages/secplus-gdo.yaml](https://github.com/CircuitSetup/circuitsetup-esphome/blob/master/packages/secplus-gdo.yaml) for a complete example.
-
-### Setup
-Import the component into your ESPHome config:
-
-```
-external_components:
-  - source: github://CircuitSetup/circuitsetup-esphome@master
-    components: [ secplus_gdo ]
-```
-
-Include the component:
-```
-secplus_gdo:
-  id: cs_gdo
-  input_gdo_pin: ${uart_rx_pin}
-  output_gdo_pin: ${uart_tx_pin}
-```
-
-### Cover
-
-```
-cover:
-  - platform: secplus_gdo
-    name: Garage Door
-    secplus_gdo_id: cs_gdo
-    id: gdo_door
-    pre_close_warning_duration: 5s
-    pre_close_warning_start:
-      - button.press: pre_close_warning
-
-```
-
-#### Configuration options
-
-* **secplus_gdo_id** (**Required**, string): The ID of the component set above.
-* **pre_close_warning_duration** (_Optional_, Time): Duration of the pre-close warning
-* **pre_close_warning_start** (_Optional_, Action): Action(s) to execute the pre-close warning
-* **pre_close_warning_end** (_Optional_, Action): Action(s) to execute when the pre-close warning stops
-* **toggle_only** (_Optional_, boolean)_: When true, all open/close commands are sent as a toggle door actions to the garage opener. This is a compatibility fix for some openers, such as some Merlin brand openers that are known to only respond to toggle commands and don't respond to discrete open/close commands.
-
-### Binary Sensors
+## Minimal Working Example
 
 ```yaml
+external_components:
+  - source: github://CircuitSetup/circuitsetup-esphome@circuitsetup-secplus-garage-door-opener-v1.4.5-esphome-v2026.2.4
+    components: [secplus_gdo]
+
+secplus_gdo:
+  id: cs_gdo
+  input_gdo_pin: GPIO2
+  output_gdo_pin: GPIO1
+
+cover:
+  - platform: secplus_gdo
+    id: gdo_door
+    name: Garage Door
+    device_class: garage
+    secplus_gdo_id: cs_gdo
+    pre_close_warning_duration: 5s
+
+light:
+  - platform: secplus_gdo
+    id: gdo_light
+    name: Garage Light
+    secplus_gdo_id: cs_gdo
+
+lock:
+  - platform: secplus_gdo
+    id: garage_lock_entity
+    name: Lock
+    secplus_gdo_id: cs_gdo
+
 binary_sensor:
   - platform: secplus_gdo
-    type: wireless_remote
+    id: gdo_motion
+    name: Motion
+    type: motion
     secplus_gdo_id: cs_gdo
-    name: Wireless Remote
 ```
 
-* **type** (**Required**, string): Sensor type. Use `wireless_remote` to detect when the door is triggered by a wireless remote.
+The component now starts automatically during setup. You do not need a separate `wifi.on_connect` automation to call `id(cs_gdo).start_gdo()`.
+
+## Entity Types
+
+`binary_sensor` types:
+- `motion`
+- `obstruction`
+- `motor`
+- `button`
+- `sync`
+- `wireless_remote`
+
+`sensor` types:
+- `openings`
+- `paired_devices_total`
+- `paired_devices_remotes`
+- `paired_devices_keypads`
+- `paired_devices_wall_controls`
+- `paired_devices_accessories`
+
+`text_sensor` types:
+- `battery`
+
+`number` types:
+- `open_duration`
+- `close_duration`
+- `client_id`
+- `rolling_code`
+
+`switch` types:
+- `learn`
+- `toggle_only`
+
+## Cover Options
+
+- `secplus_gdo_id`: required parent component ID.
+- `pre_close_warning_duration`: optional warning delay before close commands.
+- `pre_close_warning_start`: optional automation that runs when the warning starts.
+- `pre_close_warning_end`: optional automation that runs when the warning ends or is cancelled.
+
+`toggle_only` behavior is still supported through the dedicated `switch` entity. That mode is useful for openers that only accept toggle commands instead of discrete open/close commands.
+
+## Full Package Example
+
+For the complete CircuitSetup hardware package, see [packages/secplus-gdo.yaml](https://github.com/CircuitSetup/circuitsetup-esphome/blob/master/packages/secplus-gdo.yaml).

--- a/components/secplus_gdo/README.md
+++ b/components/secplus_gdo/README.md
@@ -6,7 +6,7 @@ ESPHome `2026.2.0+` custom component for Security+ garage door openers.
 
 ```yaml
 external_components:
-  - source: github://CircuitSetup/circuitsetup-esphome@circuitsetup-secplus-garage-door-opener-v1.4.5-esphome-v2026.2.4
+  - source: github://CircuitSetup/circuitsetup-esphome@master
     components: [secplus_gdo]
 
 secplus_gdo:

--- a/components/secplus_gdo/__init__.py
+++ b/components/secplus_gdo/__init__.py
@@ -19,9 +19,8 @@
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
-import voluptuous as vol
 from esphome import pins
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_NUMBER
 
 DEPENDENCIES = ["preferences"]
 MULTI_CONF = True
@@ -30,19 +29,84 @@ secplus_gdo_ns = cg.esphome_ns.namespace("secplus_gdo")
 SECPLUS_GDO = secplus_gdo_ns.class_("GDOComponent", cg.Component)
 
 CONF_OUTPUT_GDO = "output_gdo_pin"
-DEFAULT_OUTPUT_GDO = ("1")
 CONF_INPUT_GDO = "input_gdo_pin"
-DEFAULT_INPUT_GDO = ("2")
-
 CONF_SECPLUS_GDO_ID = "secplus_gdo_id"
 
-CONFIG_SCHEMA = cv.Schema(
+GDO_RESERVED_IDS = frozenset(
     {
-        cv.GenerateID(): cv.declare_id(SECPLUS_GDO),
-        cv.Required(CONF_OUTPUT_GDO): pins.gpio_output_pin_schema,
-        cv.Required(CONF_INPUT_GDO): pins.gpio_input_pin_schema,
+        "gdo_activate_learn",
+        "gdo_clear_paired_devices",
+        "gdo_deactivate_learn",
+        "gdo_deinit",
+        "gdo_door_close",
+        "gdo_door_move_to_target",
+        "gdo_door_open",
+        "gdo_door_state_to_string",
+        "gdo_door_stop",
+        "gdo_door_toggle",
+        "gdo_get_status",
+        "gdo_init",
+        "gdo_learn_state_to_string",
+        "gdo_light_off",
+        "gdo_light_on",
+        "gdo_light_state_to_string",
+        "gdo_light_toggle",
+        "gdo_lock",
+        "gdo_lock_state_to_string",
+        "gdo_motion_state_to_string",
+        "gdo_obstruction_state_to_string",
+        "gdo_paired_device_type_to_string",
+        "gdo_protocol_type_to_string",
+        "gdo_set_client_id",
+        "gdo_set_close_duration",
+        "gdo_set_min_command_interval",
+        "gdo_set_open_duration",
+        "gdo_set_protocol",
+        "gdo_set_rolling_code",
+        "gdo_set_toggle_only",
+        "gdo_start",
+        "gdo_sync",
+        "gdo_toggle_lock",
+        "gdo_unlock",
+        "gdo_motor_state_to_string",
+        "gdo_button_state_to_string",
+        "gdo_battery_state_to_string",
     }
-).extend(cv.COMPONENT_SCHEMA)
+)
+
+
+def validate_cpp_symbol_id(config, key=CONF_ID):
+    generated_id = config.get(key)
+    if generated_id is None:
+        return config
+
+    generated_name = getattr(generated_id, "id", None)
+    if generated_name in GDO_RESERVED_IDS:
+        raise cv.Invalid(
+            f"'{generated_name}' is reserved by gdolib and cannot be used as an ESPHome id. "
+            "Choose a different id to avoid generated C++ symbol collisions."
+        )
+
+    return config
+
+
+def validate_gdo_pins(config):
+    if config[CONF_OUTPUT_GDO][CONF_NUMBER] == config[CONF_INPUT_GDO][CONF_NUMBER]:
+        raise cv.Invalid("input_gdo_pin and output_gdo_pin must use different pins")
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(SECPLUS_GDO),
+            cv.Required(CONF_OUTPUT_GDO): pins.gpio_output_pin_schema,
+            cv.Required(CONF_INPUT_GDO): pins.gpio_input_pin_schema,
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    validate_gdo_pins,
+    validate_cpp_symbol_id,
+)
 
 SECPLUS_GDO_CONFIG_SCHEMA = cv.Schema(
     {
@@ -50,8 +114,9 @@ SECPLUS_GDO_CONFIG_SCHEMA = cv.Schema(
     }
 )
 
+
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    cg.add_define("GDO_UART_TX_PIN", config[CONF_OUTPUT_GDO]['number'])
-    cg.add_define("GDO_UART_RX_PIN", config[CONF_INPUT_GDO]['number'])
+    cg.add_define("GDO_UART_TX_PIN", config[CONF_OUTPUT_GDO][CONF_NUMBER])
+    cg.add_define("GDO_UART_RX_PIN", config[CONF_INPUT_GDO][CONF_NUMBER])

--- a/components/secplus_gdo/__init__.py
+++ b/components/secplus_gdo/__init__.py
@@ -21,6 +21,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.const import CONF_ID, CONF_NUMBER
+from esphome.core import CORE
 
 DEPENDENCIES = ["preferences"]
 MULTI_CONF = True
@@ -118,5 +119,13 @@ SECPLUS_GDO_CONFIG_SCHEMA = cv.Schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+
+    if CORE.is_esp32 and CORE.target_framework == "esp-idf":
+        # secplus_gdo needs to own the panic wrapper on ESP-IDF so the GDO TX pin can
+        # be forced into a safe state before panic output proceeds.
+        cg.add_build_unflag("-Wl,--wrap=esp_panic_handler")
+        cg.add_build_unflag("-DUSE_ESP32_CRASH_HANDLER")
+        cg.add_build_flag("-Wl,--wrap=esp_panic_handler")
+
     cg.add_define("GDO_UART_TX_PIN", config[CONF_OUTPUT_GDO][CONF_NUMBER])
     cg.add_define("GDO_UART_RX_PIN", config[CONF_INPUT_GDO][CONF_NUMBER])

--- a/components/secplus_gdo/binary_sensor/__init__.py
+++ b/components/secplus_gdo/binary_sensor/__init__.py
@@ -22,7 +22,7 @@ import esphome.config_validation as cv
 from esphome.components import binary_sensor
 from esphome.const import CONF_ID
 
-from .. import SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, CONF_SECPLUS_GDO_ID
+from .. import CONF_SECPLUS_GDO_ID, SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, validate_cpp_symbol_id
 
 DEPENDENCIES = ["secplus_gdo"]
 
@@ -32,23 +32,23 @@ GDOBinarySensor = secplus_gdo_ns.class_(
 
 CONF_TYPE = "type"
 TYPES = {
-    "motion": "register_motion",
-    "obstruction": "register_obstruction",
-    "motor": "register_motor",
-    "button": "register_button",
-    "sync": "register_sync",
-    "wireless_remote": "register_wireless_remote",
+    "motion": 0,
+    "obstruction": 1,
+    "motor": 2,
+    "button": 3,
+    "sync": 4,
+    "wireless_remote": 5,
 }
 
-
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
     binary_sensor.binary_sensor_schema(GDOBinarySensor)
     .extend(
         {
             cv.Required(CONF_TYPE): cv.enum(TYPES, lower=True),
         }
     )
-    .extend(SECPLUS_GDO_CONFIG_SCHEMA)
+    .extend(SECPLUS_GDO_CONFIG_SCHEMA),
+    validate_cpp_symbol_id,
 )
 
 
@@ -57,7 +57,5 @@ async def to_code(config):
     await binary_sensor.register_binary_sensor(var, config)
     await cg.register_component(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
-    fcall = str(parent) + "->" + str(TYPES[config[CONF_TYPE]])
-    text = fcall + "(std::bind(&" + str(GDOBinarySensor) + "::publish_state," + str(config[CONF_ID]) + ",std::placeholders::_1))"
-    cg.add((cg.RawExpression(text)))
-
+    cg.add(var.set_type(TYPES[config[CONF_TYPE]]))
+    cg.add(parent.register_binary_sensor(var))

--- a/components/secplus_gdo/binary_sensor/gdo_binary_sensor.h
+++ b/components/secplus_gdo/binary_sensor/gdo_binary_sensor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024  Konnected Inc.
+ * Copyright (C) 2026  CircuitSetup
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/components/secplus_gdo/binary_sensor/gdo_binary_sensor.h
+++ b/components/secplus_gdo/binary_sensor/gdo_binary_sensor.h
@@ -15,15 +15,56 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-# pragma once
+#pragma once
 
-#include "esphome/core/component.h"
+#include <cstdint>
+
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace secplus_gdo {
 
-class GDOBinarySensor : public binary_sensor::BinarySensor, public Component {};
+enum class GDOBinarySensorType : uint8_t {
+    MOTION = 0,
+    OBSTRUCTION,
+    MOTOR,
+    BUTTON,
+    SYNC,
+    WIRELESS_REMOTE,
+};
+
+class GDOBinarySensor : public binary_sensor::BinarySensor, public Component {
+public:
+    void dump_config() override { ESP_LOGCONFIG(TAG, "GDO binary sensor type: %s", this->type_to_string_()); }
+    void set_type(uint8_t type) { this->type_ = static_cast<GDOBinarySensorType>(type); }
+    GDOBinarySensorType get_type() const { return this->type_; }
+    void publish(bool state) { this->publish_state(state); }
+
+protected:
+    const char *type_to_string_() const {
+        switch (this->type_) {
+        case GDOBinarySensorType::MOTION:
+            return "motion";
+        case GDOBinarySensorType::OBSTRUCTION:
+            return "obstruction";
+        case GDOBinarySensorType::MOTOR:
+            return "motor";
+        case GDOBinarySensorType::BUTTON:
+            return "button";
+        case GDOBinarySensorType::SYNC:
+            return "sync";
+        case GDOBinarySensorType::WIRELESS_REMOTE:
+            return "wireless_remote";
+        default:
+            return "unknown";
+        }
+    }
+
+    GDOBinarySensorType type_{GDOBinarySensorType::MOTION};
+    static constexpr const char *TAG = "gdo.binary_sensor";
+};
 
 } // namespace secplus_gdo
 } // namespace esphome

--- a/components/secplus_gdo/cover/__init__.py
+++ b/components/secplus_gdo/cover/__init__.py
@@ -23,7 +23,7 @@ from esphome import automation
 from esphome.components import cover
 from esphome.const import CONF_TRIGGER_ID
 
-from .. import SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, CONF_SECPLUS_GDO_ID
+from .. import CONF_SECPLUS_GDO_ID, SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, validate_cpp_symbol_id
 
 DEPENDENCIES = ["secplus_gdo"]
 
@@ -41,7 +41,7 @@ CONF_PRE_CLOSE_WARNING_DURATION = "pre_close_warning_duration"
 CONF_PRE_CLOSE_WARNING_START = "pre_close_warning_start"
 CONF_PRE_CLOSE_WARNING_END = "pre_close_warning_end"
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
     cover.cover_schema(GDODoor)
     .extend(
         {
@@ -53,7 +53,8 @@ CONFIG_SCHEMA = (
                 {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CoverClosingEndTrigger)}
             ),
         }
-    ).extend(SECPLUS_GDO_CONFIG_SCHEMA)
+    ).extend(SECPLUS_GDO_CONFIG_SCHEMA),
+    validate_cpp_symbol_id,
 )
 
 async def to_code(config):

--- a/components/secplus_gdo/cover/gdo_door.cpp
+++ b/components/secplus_gdo/cover/gdo_door.cpp
@@ -1,12 +1,13 @@
-#include "esphome/core/log.h"
 #include "gdo_door.h"
-#include "../secplus_gdo.h"
+
+#include <functional>
 #include <utility>
+
+#include "../secplus_gdo.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace secplus_gdo {
-
-constexpr char TAG[] = "gdo_cover";
 
 void GDODoor::set_state(gdo_door_state_t state, float position) {
     if (this->pre_close_active_) {
@@ -18,6 +19,7 @@ void GDODoor::set_state(gdo_door_state_t state, float position) {
             if (this->pre_close_end_trigger) {
                 this->pre_close_end_trigger->trigger();
             }
+            this->clear_pre_close_state_();
         } else {
             // If we are in the pre-close state, and the door is not closing, then do not update
             // the state so that the stop button remains active on the front end to cancel the closing operation
@@ -53,20 +55,54 @@ void GDODoor::set_state(gdo_door_state_t state, float position) {
         break;
     }
 
-    #ifdef USE_MQTT // if MQTT component is enabled, do not publish the same state more than once
-    if (this->state_ == state && this->current_operation == this->prev_operation) { return; }
-    #endif
+#ifdef USE_MQTT // if MQTT component is enabled, do not publish the same state more than once
+    if (this->state_ == state && this->current_operation == this->prev_operation) {
+        return;
+    }
+#endif
 
     this->publish_state(false);
     this->state_ = state;
 }
 
-void GDODoor::do_action_after_warning(cover::CoverCall call) {
+bool GDODoor::send_command_(const char *action, std::function<esp_err_t()> &&command) {
+    const auto err = command();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "%s failed: %s", action, esp_err_to_name(err));
+        return false;
+    }
+    return true;
+}
 
-    if (this->pre_close_active_) {
+void GDODoor::remember_pre_close_state_() {
+    this->pre_close_restore_state_ = this->state_;
+    this->pre_close_restore_position_ = this->position;
+    this->pre_close_restore_operation_ = this->current_operation;
+    this->has_pre_close_restore_ = true;
+}
+
+void GDODoor::restore_pre_close_state_() {
+    if (!this->has_pre_close_restore_) {
         return;
     }
 
+    this->state_ = this->pre_close_restore_state_;
+    this->position = this->pre_close_restore_position_;
+    this->current_operation = this->pre_close_restore_operation_;
+    this->publish_state(false);
+    this->clear_pre_close_state_();
+}
+
+void GDODoor::clear_pre_close_state_() {
+    this->has_pre_close_restore_ = false;
+}
+
+bool GDODoor::do_action_after_warning(cover::CoverCall call) {
+    if (this->pre_close_active_) {
+        return false;
+    }
+
+    this->remember_pre_close_state_();
     this->set_state(GDO_DOOR_STATE_CLOSING, this->position);
 
     ESP_LOGD(TAG, "WARNING for %dms", this->pre_close_duration_);
@@ -74,72 +110,102 @@ void GDODoor::do_action_after_warning(cover::CoverCall call) {
         this->pre_close_start_trigger->trigger();
     }
 
-    this->set_timeout("pre_close", this->pre_close_duration_, [this, call = std::move(call)]() {
+    this->set_timeout("pre_close", this->pre_close_duration_, [this, call = std::move(call)]() mutable {
         this->pre_close_active_ = false;
         if (this->pre_close_end_trigger) {
             this->pre_close_end_trigger->trigger();
         }
-        this->do_action(call);
+        if (!this->do_action(call)) {
+            this->restore_pre_close_state_();
+        } else {
+            this->clear_pre_close_state_();
+        }
     });
 
     this->pre_close_active_ = true;
+    return true;
 }
 
-void GDODoor::do_action(const cover::CoverCall& call) {
+bool GDODoor::do_action(const cover::CoverCall &call) {
     if (this->parent_) {
         this->parent_->notify_cover_command();
     }
+
     if (call.get_toggle()) {
         ESP_LOGD(TAG, "Sending TOGGLE action");
-        gdo_door_toggle();
-        return;
+        return this->send_command_("door toggle", []() { return gdo_door_toggle(); });
     }
 
-    if (call.get_position().has_value()) {
-        auto pos = *call.get_position();
-        if (pos == COVER_OPEN) {
-            if (this->toggle_only_) {
-                ESP_LOGD(TAG, "Sending TOGGLE action");
-                gdo_door_toggle();
-                if (this->state_ == GDO_DOOR_STATE_STOPPED && this->prev_operation == COVER_OPERATION_OPENING) {
-                    // If the door was stopped while opening, then we need to toggle to stop, then toggle again to open,
-                    this->set_timeout("stop_door", 1000, []() {
-                        gdo_door_stop();
-                    });
-                    this->set_timeout("open_door", 2000, []() {
-                        gdo_door_toggle();
-                    });
-                }
-            } else {
-                ESP_LOGD(TAG, "Sending OPEN action");
-                gdo_door_open();
-            }
-        } else if (pos == COVER_CLOSED) {
-            if (this->toggle_only_) {
-                ESP_LOGD(TAG, "Sending TOGGLE action");
-                gdo_door_toggle();
-                if (this->state_ == GDO_DOOR_STATE_STOPPED && this->prev_operation == COVER_OPERATION_CLOSING) {
-                    // If the door was stopped while closing, then we need to toggle to stop, then toggle again to close,
-                    this->set_timeout("stop_door", 1000, []() {
-                        gdo_door_stop();
-                    });
-                    this->set_timeout("close_door", 2000, []() {
-                        gdo_door_toggle();
-                    });
-                }
-            } else {
-                ESP_LOGD(TAG, "Sending CLOSE action");
-                gdo_door_close();
-            }
-        } else {
-            ESP_LOGD(TAG, "Moving garage door to position %f", pos);
-            gdo_door_move_to_target(10000 - (pos * 10000));
-        }
+    if (!call.get_position().has_value()) {
+        return false;
     }
+
+    auto pos = *call.get_position();
+    if (pos == COVER_OPEN) {
+        if (this->toggle_only_) {
+            ESP_LOGD(TAG, "Sending TOGGLE action");
+            if (!this->send_command_("door toggle", []() { return gdo_door_toggle(); })) {
+                return false;
+            }
+            if (this->state_ == GDO_DOOR_STATE_STOPPED && this->prev_operation == COVER_OPERATION_OPENING) {
+                // If the door was stopped while opening, then we need to toggle to stop, then toggle again to open,
+                this->set_timeout("stop_door", 1000, []() {
+                    const auto err = gdo_door_stop();
+                    if (err != ESP_OK) {
+                        ESP_LOGE(TAG, "door stop failed: %s", esp_err_to_name(err));
+                    }
+                });
+                this->set_timeout("open_door", 2000, []() {
+                    const auto err = gdo_door_toggle();
+                    if (err != ESP_OK) {
+                        ESP_LOGE(TAG, "door reopen toggle failed: %s", esp_err_to_name(err));
+                    }
+                });
+            }
+            return true;
+        }
+
+        ESP_LOGD(TAG, "Sending OPEN action");
+        return this->send_command_("door open", []() { return gdo_door_open(); });
+    }
+
+    if (pos == COVER_CLOSED) {
+        if (this->toggle_only_) {
+            ESP_LOGD(TAG, "Sending TOGGLE action");
+            if (!this->send_command_("door toggle", []() { return gdo_door_toggle(); })) {
+                return false;
+            }
+            if (this->state_ == GDO_DOOR_STATE_STOPPED && this->prev_operation == COVER_OPERATION_CLOSING) {
+                // If the door was stopped while closing, then we need to toggle to stop, then toggle again to close,
+                this->set_timeout("stop_door", 1000, []() {
+                    const auto err = gdo_door_stop();
+                    if (err != ESP_OK) {
+                        ESP_LOGE(TAG, "door stop failed: %s", esp_err_to_name(err));
+                    }
+                });
+                this->set_timeout("close_door", 2000, []() {
+                    const auto err = gdo_door_toggle();
+                    if (err != ESP_OK) {
+                        ESP_LOGE(TAG, "door reclose toggle failed: %s", esp_err_to_name(err));
+                    }
+                });
+            }
+            return true;
+        }
+
+        ESP_LOGD(TAG, "Sending CLOSE action");
+        return this->send_command_("door close", []() { return gdo_door_close(); });
+    }
+
+    ESP_LOGD(TAG, "Moving garage door to position %f", pos);
+    return this->send_command_("door move_to_target", [pos]() {
+        return gdo_door_move_to_target(static_cast<uint32_t>(10000 - (pos * 10000)));
+    });
 }
 
-void GDODoor::control(const cover::CoverCall& call) {
+void GDODoor::control(const cover::CoverCall &call) {
     if (!this->synced_) {
+        ESP_LOGW(TAG, "Ignoring cover command while opener is not synced");
         this->publish_state(false);
         return;
     }
@@ -147,93 +213,115 @@ void GDODoor::control(const cover::CoverCall& call) {
     if (call.get_stop()) {
         ESP_LOGD(TAG, "Stop command received");
         this->cancel_pre_close_warning();
-        gdo_door_stop();
+        if (!this->send_command_("door stop", []() { return gdo_door_stop(); })) {
+            this->publish_state(false);
+        }
         return;
     }
 
     if (call.get_toggle()) {
         ESP_LOGD(TAG, "Toggle command received");
         if (this->position != COVER_CLOSED) {
-            this->target_position_ = COVER_CLOSED;
-            this->do_action_after_warning(call);
-        } else {
+            if (this->do_action_after_warning(call)) {
+                this->target_position_ = COVER_CLOSED;
+            } else {
+                this->publish_state(false);
+            }
+        } else if (this->do_action(call)) {
             this->target_position_ = COVER_OPEN;
-            this->do_action(call);
+        } else {
+            this->publish_state(false);
         }
-
         return;
     }
 
-    if (call.get_position().has_value()) {
-        auto pos = *call.get_position();
-        if (this->position == pos) {
-            ESP_LOGD(TAG, "Door is already %s", pos == COVER_OPEN ? "open" : "closed");
-            this->publish_state(false);
-            return;
-        }
-
-        if ((this->current_operation == COVER_OPERATION_OPENING && pos > this->position) ||
-            (this->current_operation == COVER_OPERATION_CLOSING && pos < this->position)) {
-            ESP_LOGD(TAG, "Door is already moving in target direction; target position: %.0f%%", *this->target_position_);
-            this->publish_state(false);
-            return;
-        }
-
-        if (this->pre_close_active_) {
-            // don't start the pre-close again if the door is already going to close.
-            if (pos < this->position) {
-                ESP_LOGD(TAG, "Door is already closing");
-                this->publish_state(false);
-                return;
-            }
-
-            ESP_LOGD(TAG, "Canceling pending action");
-            this->cancel_timeout("pre_close");
-            this->pre_close_active_ = false;
-            if (this->pre_close_end_trigger) {
-                this->pre_close_end_trigger->trigger();
-            }
-        }
-
-        if (this->current_operation == COVER_OPERATION_OPENING ||
-            this->current_operation == COVER_OPERATION_CLOSING) {
-            ESP_LOGD(TAG, "Door is in motion - Sending STOP action");
-            gdo_door_stop();
-        }
-
-        if (pos == COVER_OPEN) {
-            ESP_LOGD(TAG, "Open command received");
-            this->do_action(call);
-        } else if (pos == COVER_CLOSED) {
-            ESP_LOGD(TAG, "Close command received");
-            this->do_action_after_warning(call);
-        } else {
-            ESP_LOGD(TAG, "Move to position %f command received", pos);
-            if (pos < this->position) {
-                ESP_LOGV(TAG, "Current position: %f; Intended position: %f; Door will move down after warning", this->position, pos);
-                this->do_action_after_warning(call);
-            } else {
-                ESP_LOGV(TAG, "Current position: %f; Intended position: %f; Door will move up immediately", this->position, pos);
-                this->do_action(call);
-            }
-        }
-
-        this->target_position_ = pos;
+    if (!call.get_position().has_value()) {
+        return;
     }
-}
 
+    auto pos = *call.get_position();
+    if (this->position == pos) {
+        if (pos == COVER_OPEN) {
+            ESP_LOGD(TAG, "Door is already open");
+        } else if (pos == COVER_CLOSED) {
+            ESP_LOGD(TAG, "Door is already closed");
+        } else {
+            ESP_LOGD(TAG, "Door is already at %.0f%%", pos * 100.0f);
+        }
+        this->publish_state(false);
+        return;
+    }
 
-void GDODoor::cancel_pre_close_warning() {
+    if ((this->current_operation == COVER_OPERATION_OPENING && pos > this->position) ||
+        (this->current_operation == COVER_OPERATION_CLOSING && pos < this->position)) {
+        ESP_LOGD(TAG, "Door is already moving in target direction; target position: %.0f%%", pos * 100.0f);
+        this->publish_state(false);
+        return;
+    }
+
     if (this->pre_close_active_) {
-        ESP_LOGD(TAG, "Canceling pending pre-close warning");
+        // don't start the pre-close again if the door is already going to close.
+        if (pos < this->position) {
+            ESP_LOGD(TAG, "Door is already closing");
+            this->publish_state(false);
+            return;
+        }
+
+        ESP_LOGD(TAG, "Canceling pending action");
         this->cancel_timeout("pre_close");
         this->pre_close_active_ = false;
         if (this->pre_close_end_trigger) {
             this->pre_close_end_trigger->trigger();
         }
-        this->set_state(GDO_DOOR_STATE_OPEN, this->position);
+        this->restore_pre_close_state_();
+    }
+
+    if (this->current_operation == COVER_OPERATION_OPENING ||
+        this->current_operation == COVER_OPERATION_CLOSING) {
+        ESP_LOGD(TAG, "Door is in motion - Sending STOP action");
+        if (!this->send_command_("door stop", []() { return gdo_door_stop(); })) {
+            this->publish_state(false);
+            return;
+        }
+    }
+
+    bool action_started = false;
+    if (pos == COVER_OPEN) {
+        ESP_LOGD(TAG, "Open command received");
+        action_started = this->do_action(call);
+    } else if (pos == COVER_CLOSED) {
+        ESP_LOGD(TAG, "Close command received");
+        action_started = this->do_action_after_warning(call);
+    } else {
+        ESP_LOGD(TAG, "Move to position %f command received", pos);
+        if (pos < this->position) {
+            ESP_LOGV(TAG, "Current position: %f; Intended position: %f; Door will move down after warning", this->position, pos);
+            action_started = this->do_action_after_warning(call);
+        } else {
+            ESP_LOGV(TAG, "Current position: %f; Intended position: %f; Door will move up immediately", this->position, pos);
+            action_started = this->do_action(call);
+        }
+    }
+
+    if (action_started) {
+        this->target_position_ = pos;
+    } else {
         this->publish_state(false);
     }
+}
+
+void GDODoor::cancel_pre_close_warning() {
+    if (!this->pre_close_active_) {
+        return;
+    }
+
+    ESP_LOGD(TAG, "Canceling pending pre-close warning");
+    this->cancel_timeout("pre_close");
+    this->pre_close_active_ = false;
+    if (this->pre_close_end_trigger) {
+        this->pre_close_end_trigger->trigger();
+    }
+    this->restore_pre_close_state_();
 }
 
 } // namespace secplus_gdo

--- a/components/secplus_gdo/cover/gdo_door.cpp
+++ b/components/secplus_gdo/cover/gdo_door.cpp
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2024  Konnected Inc.
+ * Copyright (C) 2026  CircuitSetup
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "gdo_door.h"
 
 #include <functional>

--- a/components/secplus_gdo/cover/gdo_door.h
+++ b/components/secplus_gdo/cover/gdo_door.h
@@ -17,10 +17,14 @@
 
 #pragma once
 
+#include <functional>
+
+#include "automation.h"
 #include "esphome/components/cover/cover.h"
 #include "esphome/core/component.h"
-#include "automation.h"
+#include "esphome/core/log.h"
 #include "gdo.h"
+#include "inttypes.h"
 
 namespace esphome {
 namespace secplus_gdo {
@@ -30,6 +34,12 @@ class GDOComponent;
 using namespace esphome::cover;
     class GDODoor : public cover::Cover, public Component {
     public:
+        void dump_config() override {
+            ESP_LOGCONFIG(TAG, "GDO cover configured");
+            ESP_LOGCONFIG(TAG, "  Pre-close warning duration: %" PRIu32 " ms", this->pre_close_duration_);
+            ESP_LOGCONFIG(TAG, "  Toggle-only mode: %s", this->toggle_only_ ? "YES" : "NO");
+        }
+
         [[nodiscard]] cover::CoverTraits get_traits() override {
             CoverTraits traits;
             traits.set_supports_stop(true);
@@ -46,12 +56,10 @@ using namespace esphome::cover;
             this->pre_close_end_trigger = trigger;
         }
 
-        void set_sync_state(bool synced) {
-            this->synced_ = synced;
-        }
+        void set_sync_state(bool synced) { this->synced_ = synced; }
 
-        void do_action(const cover::CoverCall& call);
-        void do_action_after_warning(cover::CoverCall call);
+        bool do_action(const cover::CoverCall &call);
+        bool do_action_after_warning(cover::CoverCall call);
         void set_pre_close_warning_duration(uint32_t ms) { this->pre_close_duration_ = ms; }
         void set_toggle_only(bool val) { this->toggle_only_ = val; }
         void set_state(gdo_door_state_t state, float position);
@@ -59,18 +67,28 @@ using namespace esphome::cover;
         void set_parent(GDOComponent *parent) { this->parent_ = parent; }
 
     protected:
-        void control(const cover::CoverCall& call);
+        void control(const cover::CoverCall &call) override;
+        bool send_command_(const char *action, std::function<esp_err_t()> &&command);
+        void remember_pre_close_state_();
+        void restore_pre_close_state_();
+        void clear_pre_close_state_();
 
         CoverClosingStartTrigger *pre_close_start_trigger{nullptr};
         CoverClosingEndTrigger   *pre_close_end_trigger{nullptr};
-        uint32_t                 pre_close_duration_{0};
-        bool                     pre_close_active_{false};
-        bool                     toggle_only_{false};
-        optional<float>          target_position_{0};
-        CoverOperation           prev_operation{COVER_OPERATION_IDLE};
-        gdo_door_state_t         state_{GDO_DOOR_STATE_UNKNOWN};
-        bool                     synced_{false};
-        GDOComponent            *parent_{nullptr};
+        uint32_t                  pre_close_duration_{0};
+        bool                      pre_close_active_{false};
+        bool                      toggle_only_{false};
+        optional<float>           target_position_{};
+        CoverOperation            prev_operation{COVER_OPERATION_IDLE};
+        gdo_door_state_t          state_{GDO_DOOR_STATE_UNKNOWN};
+        bool                      synced_{false};
+        GDOComponent             *parent_{nullptr};
+        gdo_door_state_t          pre_close_restore_state_{GDO_DOOR_STATE_UNKNOWN};
+        float                     pre_close_restore_position_{COVER_OPEN};
+        CoverOperation            pre_close_restore_operation_{COVER_OPERATION_IDLE};
+        bool                      has_pre_close_restore_{false};
+        static constexpr const char *TAG = "gdo_cover";
     };
+
 } // namespace secplus_gdo
 } // namespace esphome

--- a/components/secplus_gdo/cover/gdo_door.h
+++ b/components/secplus_gdo/cover/gdo_door.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024  Konnected Inc.
+ * Copyright (C) 2026  CircuitSetup
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/components/secplus_gdo/light/__init__.py
+++ b/components/secplus_gdo/light/__init__.py
@@ -22,18 +22,19 @@ import esphome.config_validation as cv
 from esphome.components import light
 from esphome.const import CONF_OUTPUT_ID  # New in 2023.5
 
-from .. import SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, CONF_SECPLUS_GDO_ID
+from .. import CONF_SECPLUS_GDO_ID, SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, validate_cpp_symbol_id
 
 DEPENDENCIES = ["secplus_gdo"]
 
-GDOLight = secplus_gdo_ns.class_(
-    "GDOLight", light.LightOutput, cg.Component
+GDOLight = secplus_gdo_ns.class_("GDOLight", light.LightOutput, cg.Component)
+
+CONFIG_SCHEMA = cv.All(
+    light.light_schema(
+        GDOLight,
+        light.LightType.BINARY,
+    ).extend(SECPLUS_GDO_CONFIG_SCHEMA),
+    lambda config: validate_cpp_symbol_id(config, CONF_OUTPUT_ID),
 )
-
-
-CONFIG_SCHEMA = light.LIGHT_SCHEMA.extend(
-    {cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(GDOLight)}
-).extend(SECPLUS_GDO_CONFIG_SCHEMA)
 
 
 async def to_code(config):

--- a/components/secplus_gdo/light/gdo_light.h
+++ b/components/secplus_gdo/light/gdo_light.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024  Konnected Inc.
+ * Copyright (C) 2026  CircuitSetup
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/components/secplus_gdo/light/gdo_light.h
+++ b/components/secplus_gdo/light/gdo_light.h
@@ -17,28 +17,43 @@
 
 #pragma once
 
+#include "esphome/components/light/light_output.h"
 #include "esphome/core/component.h"
-#include "esphome/components/binary/light/binary_light_output.h"
+#include "esphome/core/log.h"
 #include "gdo.h"
 
 namespace esphome {
 namespace secplus_gdo {
 
-class GDOLight : public binary::BinaryLightOutput, public Component {
+class GDOLight : public light::LightOutput, public Component {
     public:
+        void dump_config() override { ESP_LOGCONFIG(TAG, "GDO light configured"); }
+
+        light::LightTraits get_traits() override {
+            auto traits = light::LightTraits();
+            traits.set_supported_color_modes({light::ColorMode::ON_OFF});
+            return traits;
+        }
+
         void setup_state(light::LightState *state) override { this->state_ = state; }
 
         void write_state(light::LightState *state) override {
             if (!this->synced_) {
+                ESP_LOGW(TAG, "Ignoring light command while opener is not synced");
+                return;
+            }
+
+            if (state == nullptr) {
+                ESP_LOGE(TAG, "Cannot control light without a valid LightState");
                 return;
             }
 
             bool binary;
             state->current_values_as_binary(&binary);
-            if (binary)
-                gdo_light_on();
-            else
-                gdo_light_off();
+            const auto err = binary ? gdo_light_on() : gdo_light_off();
+            if (err != ESP_OK) {
+                ESP_LOGE(TAG, "Failed to send light command: %s", esp_err_to_name(err));
+            }
         }
 
         void set_state(gdo_light_state_t state) {
@@ -48,15 +63,18 @@ class GDOLight : public binary::BinaryLightOutput, public Component {
 
             this->light_state_ = state;
             ESP_LOGI(TAG, "Light state: %s", gdo_light_state_to_string(state));
-            bool is_on = state == GDO_LIGHT_STATE_ON;
+            if (this->state_ == nullptr) {
+                ESP_LOGW(TAG, "Skipping light publish because LightState is not ready yet");
+                return;
+            }
+
+            const bool is_on = state == GDO_LIGHT_STATE_ON;
             this->state_->current_values.set_state(is_on);
             this->state_->remote_values.set_state(is_on);
             this->state_->publish_state();
         }
 
-        void set_sync_state(bool synced) {
-            this->synced_ = synced;
-        }
+        void set_sync_state(bool synced) { this->synced_ = synced; }
 
     private:
         light::LightState *state_{nullptr};

--- a/components/secplus_gdo/lock/__init__.py
+++ b/components/secplus_gdo/lock/__init__.py
@@ -21,23 +21,16 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import lock
 
-from .. import SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, CONF_SECPLUS_GDO_ID
+from .. import CONF_SECPLUS_GDO_ID, SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, validate_cpp_symbol_id
 
 DEPENDENCIES = ["secplus_gdo"]
 
 GDOLock = secplus_gdo_ns.class_("GDOLock", lock.Lock, cg.Component)
 
-CONFIG_SCHEMA = (
-    lock.lock_schema(GDOLock)
-    .extend(
-        {
-            cv.GenerateID(): cv.declare_id(GDOLock),
-        }
-    )
-    .extend(SECPLUS_GDO_CONFIG_SCHEMA)
+CONFIG_SCHEMA = cv.All(
+    lock.lock_schema(GDOLock).extend(SECPLUS_GDO_CONFIG_SCHEMA),
+    validate_cpp_symbol_id,
 )
-
-
 
 async def to_code(config):
     var = await lock.new_lock(config)

--- a/components/secplus_gdo/lock/gdo_lock.h
+++ b/components/secplus_gdo/lock/gdo_lock.h
@@ -19,13 +19,16 @@
 
 #include "esphome/components/lock/lock.h"
 #include "esphome/core/component.h"
+#include "esphome/core/log.h"
 #include "gdo.h"
 
 namespace esphome {
 namespace secplus_gdo {
 
     class GDOLock : public lock::Lock, public Component {
-        public:
+    public:
+        void dump_config() override { ESP_LOGCONFIG(TAG, "GDO lock configured"); }
+
         void set_state(gdo_lock_state_t state) {
             if (state == this->lock_state_) {
                 return;
@@ -38,17 +41,31 @@ namespace secplus_gdo {
                                          lock::LockState::LOCK_STATE_UNLOCKED);
         }
 
-        void control(const lock::LockCall& call) override {
+        void control(const lock::LockCall &call) override {
             if (!this->synced_) {
+                ESP_LOGW(TAG, "Ignoring lock command while opener is not synced");
+                return;
+            }
+
+            if (!call.get_state().has_value()) {
+                ESP_LOGE(TAG, "Lock control called without a target state");
                 return;
             }
 
             auto state = *call.get_state();
+            esp_err_t err = ESP_OK;
 
             if (state == lock::LockState::LOCK_STATE_LOCKED) {
-                gdo_lock();
+                err = gdo_lock();
             } else if (state == lock::LockState::LOCK_STATE_UNLOCKED) {
-                gdo_unlock();
+                err = gdo_unlock();
+            } else {
+                ESP_LOGE(TAG, "Unsupported lock state requested");
+                return;
+            }
+
+            if (err != ESP_OK) {
+                ESP_LOGE(TAG, "Failed to send lock command: %s", esp_err_to_name(err));
             }
         }
 
@@ -56,10 +73,10 @@ namespace secplus_gdo {
             this->synced_ = synced;
         }
 
-        private:
+    private:
         gdo_lock_state_t lock_state_{GDO_LOCK_STATE_MAX};
         bool synced_{false};
-        static constexpr const char* TAG = "GDOLock";
+        static constexpr const char *TAG = "GDOLock";
     };
 
 } // namespace secplus_gdo

--- a/components/secplus_gdo/lock/gdo_lock.h
+++ b/components/secplus_gdo/lock/gdo_lock.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024  Konnected Inc.
+ * Copyright (C) 2026  CircuitSetup
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/components/secplus_gdo/number/__init__.py
+++ b/components/secplus_gdo/number/__init__.py
@@ -22,7 +22,7 @@ import esphome.config_validation as cv
 from esphome.components import number
 from esphome.const import CONF_ID
 
-from .. import SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, CONF_SECPLUS_GDO_ID
+from .. import CONF_SECPLUS_GDO_ID, SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, validate_cpp_symbol_id
 
 DEPENDENCIES = ["secplus_gdo"]
 
@@ -30,34 +30,31 @@ GDONumber = secplus_gdo_ns.class_("GDONumber", number.Number, cg.Component)
 
 CONF_TYPE = "type"
 TYPES = {
-    "open_duration": "register_open_duration",
-    "close_duration": "register_close_duration",
-    "client_id": "register_client_id",
-    "rolling_code": "register_rolling_code",
+    "open_duration": 0,
+    "close_duration": 1,
+    "client_id": 2,
+    "rolling_code": 3,
 }
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
     number.number_schema(GDONumber)
     .extend(
         {
             cv.Required(CONF_TYPE): cv.enum(TYPES, lower=True),
         }
     )
-    .extend(SECPLUS_GDO_CONFIG_SCHEMA)
+    .extend(SECPLUS_GDO_CONFIG_SCHEMA),
+    validate_cpp_symbol_id,
 )
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    if "duration" in str(config[CONF_TYPE]):
-        await number.register_number(var, config, min_value=0x0, max_value=0xffff, step=1)
-    elif "client_id" in str(config[CONF_TYPE]):
-        await number.register_number(var, config, min_value=0x0, max_value=0xffffffff, step=1)
+    if config[CONF_TYPE] in ("open_duration", "close_duration"):
+        await number.register_number(var, config, min_value=0x0, max_value=0xFFFF, step=1)
     else:
-        await number.register_number(var, config, min_value=0x0, max_value=0xffffffff, step=1)
+        await number.register_number(var, config, min_value=0x0, max_value=0xFFFFFFFF, step=1)
     await cg.register_component(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
-    fcall = str(parent) + "->" + str(TYPES[config[CONF_TYPE]])
-    text = fcall + "(" + str(var) + ")"
-    cg.add((cg.RawExpression(text)))
-    text = "gdo_set_" + str(config[CONF_TYPE])
-    cg.add(var.set_control_function(cg.RawExpression(text)))
+    cg.add(var.set_type(TYPES[config[CONF_TYPE]]))
+    cg.add(parent.register_number(var))

--- a/components/secplus_gdo/number/gdo_number.h
+++ b/components/secplus_gdo/number/gdo_number.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024  Konnected Inc.
+ * Copyright (C) 2026  CircuitSetup
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/components/secplus_gdo/number/gdo_number.h
+++ b/components/secplus_gdo/number/gdo_number.h
@@ -15,54 +15,96 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-# pragma once
+#pragma once
 
-#include "esphome/core/component.h"
-#include "esphome/core/preferences.h"
+#include <utility>
+
 #include "esphome/components/number/number.h"
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/core/preferences.h"
+#include "gdo.h"
 
 namespace esphome {
 namespace secplus_gdo {
 
+enum class GDONumberType : uint8_t {
+    OPEN_DURATION = 0,
+    CLOSE_DURATION,
+    CLIENT_ID,
+    ROLLING_CODE,
+};
+
 class GDONumber : public number::Number, public Component {
-    public:
-        void dump_config() override {}
-        void setup() override {
-            float value;
-            this->pref_ = this->make_entity_preference<float>();
-            if (!this->pref_.load(&value)) {
-                value = 0;
-            }
+public:
+    void dump_config() override { ESP_LOGCONFIG(TAG, "GDO number type: %s", this->type_to_string_()); }
+    void set_type(uint8_t type) { this->type_ = static_cast<GDONumberType>(type); }
+    GDONumberType get_type() const { return this->type_; }
 
-            this->control(value);
+    void setup() override {
+        double value = 0;
+        this->pref_ = this->make_entity_preference<double>();
+        if (!this->pref_.load(&value)) {
+            return;
         }
 
-        void update_state(float value) {
-            if (value == this->state) {
-                return;
-            }
+        this->control(static_cast<float>(value));
+    }
 
-            this->state = value;
-            this->publish_state(value);
-            this->pref_.save(&value);
+    void update_state(double value) {
+        if (this->has_state_ && value == this->state) {
+            return;
         }
 
-        void control(float value) override {
-            if (value == this->state) {
-                return;
-            }
+        this->state = static_cast<float>(value);
+        this->publish_state(static_cast<float>(value));
+        this->pref_.save(&value);
+        this->has_state_ = true;
+    }
 
-            if (this->f_control) {
-                this->f_control(value);
-                this->update_state(value);
-            }
+    void control(float value) override {
+        if (this->has_state_ && value == this->state) {
+            return;
         }
 
-        void set_control_function(std::function<int(float)> f) { f_control = f; }
+        if (!this->f_control) {
+            ESP_LOGW(TAG, "No control function configured for %s", this->type_to_string_());
+            return;
+        }
 
-    protected:
-        ESPPreferenceObject pref_;
-        std::function<int(float)> f_control{nullptr};
-    };
+        const auto err = this->f_control(value);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to set %s: %s", this->type_to_string_(), esp_err_to_name(err));
+            return;
+        }
+
+        this->update_state(value);
+    }
+
+    void set_control_function(std::function<esp_err_t(float)> f) { this->f_control = std::move(f); }
+
+protected:
+    const char *type_to_string_() const {
+        switch (this->type_) {
+        case GDONumberType::OPEN_DURATION:
+            return "open_duration";
+        case GDONumberType::CLOSE_DURATION:
+            return "close_duration";
+        case GDONumberType::CLIENT_ID:
+            return "client_id";
+        case GDONumberType::ROLLING_CODE:
+            return "rolling_code";
+        default:
+            return "unknown";
+        }
+    }
+
+    GDONumberType type_{GDONumberType::OPEN_DURATION};
+    ESPPreferenceObject pref_;
+    std::function<esp_err_t(float)> f_control{nullptr};
+    bool has_state_{false};
+    static constexpr const char *TAG = "gdo.number";
+};
+
 } // namespace secplus_gdo
 } // namespace esphome

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024  Konnected Inc.
+ * Copyright (C) 2026  CircuitSetup
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -18,6 +18,7 @@
 #include "secplus_gdo.h"
 
 #include "driver/gpio.h"
+#include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "inttypes.h"
@@ -440,6 +441,9 @@ namespace secplus_gdo {
 
 // Need to wrap the panic handler to disable the GDO TX pin and pull the output high to
 // prevent spuriously triggering the GDO to open when the ESP32 panics.
+// ESPHome 2026.3.0+ provides its own ESP32 crash handler wrapper, so only install the
+// local wrapper when that built-in handler is not in use.
+#if !defined(USE_ESP32_CRASH_HANDLER)
 extern "C" {
 #include "hal/gpio_hal.h"
 
@@ -455,3 +459,4 @@ void __wrap_esp_panic_handler(void *info) {
     __real_esp_panic_handler(info);
 }
 } // extern "C"
+#endif

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -16,22 +16,28 @@
  */
 
 #include "secplus_gdo.h"
-#include "esphome/core/application.h"
+
+#include "driver/gpio.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "inttypes.h"
-#include <functional>
-#include "driver/gpio.h"
 
 namespace esphome {
 namespace secplus_gdo {
 
     constexpr char TAG[] = "secplus_gdo";
 
-    static void gdo_event_handler(const gdo_status_t* status, gdo_cb_event_t event, void *arg) {
-        GDOComponent *gdo = static_cast<GDOComponent *>(arg);
+    static void gdo_event_handler(const gdo_status_t *status, gdo_cb_event_t event, void *arg) {
+        auto *gdo = static_cast<GDOComponent *>(arg);
+        if (gdo == nullptr || status == nullptr) {
+            ESP_LOGE(TAG, "Received invalid callback state from gdolib");
+            return;
+        }
+
         switch (event) {
         case GDO_CB_EVENT_SYNCED:
-            ESP_LOGI(TAG, "Synced: %s, protocol: %s", status->synced ? "true" : "false", gdo_protocol_type_to_string(status->protocol));
+            ESP_LOGI(TAG, "Synced: %s, protocol: %s", status->synced ? "true" : "false",
+                     gdo_protocol_type_to_string(status->protocol));
             if (status->protocol == GDO_PROTOCOL_SEC_PLUS_V2) {
                 ESP_LOGI(TAG, "Client ID: %" PRIu32 ", Rolling code: %" PRIu32, status->client_id, status->rolling_code);
                 if (status->synced) {
@@ -42,11 +48,15 @@ namespace secplus_gdo {
             }
 
             if (!status->synced) {
-                if (gdo_set_rolling_code(status->rolling_code + 100) != ESP_OK) {
+                const auto next_rolling_code = status->rolling_code + 100;
+                if (gdo_set_rolling_code(next_rolling_code) != ESP_OK) {
                     ESP_LOGE(TAG, "Failed to set rolling code");
                 } else {
-                    ESP_LOGI(TAG, "Rolling code set to %" PRIu32 ", retryng sync", status->rolling_code);
-                    gdo_sync();
+                    ESP_LOGI(TAG, "Rolling code set to %" PRIu32 ", retrying sync", next_rolling_code);
+                    const auto err = gdo_sync();
+                    if (err != ESP_OK) {
+                        ESP_LOGE(TAG, "Failed to start resync: %s", esp_err_to_name(err));
+                    }
                 }
             } else {
                 gdo->set_protocol_state(status->protocol);
@@ -61,7 +71,7 @@ namespace secplus_gdo {
             gdo->set_lock_state(status->lock);
             break;
         case GDO_CB_EVENT_DOOR_POSITION: {
-            float position = (float)(10000 - status->door_position)/10000.0f;
+            const float position = static_cast<float>(10000 - status->door_position) / 10000.0f;
             gdo->set_door_state(status->door, position);
             if (status->door != GDO_DOOR_STATE_OPENING && status->door != GDO_DOOR_STATE_CLOSING) {
                 gdo->set_motor_state(GDO_MOTOR_STATE_OFF);
@@ -69,7 +79,8 @@ namespace secplus_gdo {
             break;
         }
         case GDO_CB_EVENT_LEARN:
-            //ESP_LOGI(TAG, "Learn: %s", gdo_learn_state_to_string(status->learn));
+            ESP_LOGI(TAG, "Learn: %s", gdo_learn_state_to_string(status->learn));
+            gdo->set_learn_state(status->learn);
             break;
         case GDO_CB_EVENT_OBSTRUCTION:
             ESP_LOGI(TAG, "Obstruction: %s", gdo_obstruction_state_to_string(status->obstruction));
@@ -100,9 +111,10 @@ namespace secplus_gdo {
             break;
         case GDO_CB_EVENT_PAIRED_DEVICES:
             ESP_LOGI(TAG, "Paired devices: %d remotes, %d keypads, %d wall controls, %d accessories, %d total",
-                    status->paired_devices.total_remotes, status->paired_devices.total_keypads,
-                    status->paired_devices.total_wall_controls, status->paired_devices.total_accessories,
-                    status->paired_devices.total_all);
+                     status->paired_devices.total_remotes, status->paired_devices.total_keypads,
+                     status->paired_devices.total_wall_controls, status->paired_devices.total_accessories,
+                     status->paired_devices.total_all);
+            gdo->set_paired_devices(status->paired_devices);
             break;
         case GDO_CB_EVENT_OPEN_DURATION_MEASUREMENT:
             ESP_LOGI(TAG, "Open duration: %d", status->open_ms);
@@ -118,58 +130,308 @@ namespace secplus_gdo {
         }
     }
 
-    void GDOComponent::setup() {
-        // Set the toggle only state and control here because we cannot guarantee the cover instance was created before the switch
-        this->door_->set_toggle_only(this->toggle_only_switch_->state);
-        this->toggle_only_switch_->set_control_function(
-            std::bind_front(&esphome::secplus_gdo::GDODoor::set_toggle_only, this->door_));
+    void GDOComponent::start_gdo() {
+        this->start_requested_ = true;
+        this->start_if_ready_();
+    }
 
+    void GDOComponent::register_binary_sensor(GDOBinarySensor *sensor) {
+        if (sensor == nullptr) {
+            return;
+        }
+
+        switch (sensor->get_type()) {
+        case GDOBinarySensorType::MOTION:
+            this->motion_sensor_ = sensor;
+            break;
+        case GDOBinarySensorType::OBSTRUCTION:
+            this->obstruction_sensor_ = sensor;
+            break;
+        case GDOBinarySensorType::MOTOR:
+            this->motor_sensor_ = sensor;
+            break;
+        case GDOBinarySensorType::BUTTON:
+            this->button_sensor_ = sensor;
+            break;
+        case GDOBinarySensorType::SYNC:
+            this->sync_sensor_ = sensor;
+            break;
+        case GDOBinarySensorType::WIRELESS_REMOTE:
+            this->wireless_remote_sensor_ = sensor;
+            break;
+        }
+    }
+
+    void GDOComponent::register_sensor(GDOStat *sensor) {
+        if (sensor == nullptr) {
+            return;
+        }
+
+        switch (sensor->get_type()) {
+        case GDOStatType::OPENINGS:
+            this->openings_sensor_ = sensor;
+            break;
+        case GDOStatType::PAIRED_DEVICES_TOTAL:
+            this->paired_total_sensor_ = sensor;
+            break;
+        case GDOStatType::PAIRED_DEVICES_REMOTES:
+            this->paired_remotes_sensor_ = sensor;
+            break;
+        case GDOStatType::PAIRED_DEVICES_KEYPADS:
+            this->paired_keypads_sensor_ = sensor;
+            break;
+        case GDOStatType::PAIRED_DEVICES_WALL_CONTROLS:
+            this->paired_wall_controls_sensor_ = sensor;
+            break;
+        case GDOStatType::PAIRED_DEVICES_ACCESSORIES:
+            this->paired_accessories_sensor_ = sensor;
+            break;
+        }
+    }
+
+    void GDOComponent::register_text_sensor(GDOTextSensor *sensor) {
+        if (sensor == nullptr) {
+            return;
+        }
+
+        switch (sensor->get_type()) {
+        case GDOTextSensorType::BATTERY:
+            this->battery_sensor_ = sensor;
+            break;
+        }
+    }
+
+    void GDOComponent::register_number(GDONumber *num) {
+        if (num == nullptr) {
+            return;
+        }
+
+        switch (num->get_type()) {
+        case GDONumberType::OPEN_DURATION:
+            this->open_duration_ = num;
+            num->set_control_function([](float value) { return gdo_set_open_duration(static_cast<uint16_t>(value)); });
+            break;
+        case GDONumberType::CLOSE_DURATION:
+            this->close_duration_ = num;
+            num->set_control_function([](float value) { return gdo_set_close_duration(static_cast<uint16_t>(value)); });
+            break;
+        case GDONumberType::CLIENT_ID:
+            this->client_id_ = num;
+            num->set_control_function([](float value) { return gdo_set_client_id(static_cast<uint32_t>(value)); });
+            break;
+        case GDONumberType::ROLLING_CODE:
+            this->rolling_code_ = num;
+            num->set_control_function([](float value) { return gdo_set_rolling_code(static_cast<uint32_t>(value)); });
+            break;
+        }
+    }
+
+    void GDOComponent::register_switch(GDOSwitch *sw) {
+        if (sw == nullptr) {
+            return;
+        }
+
+        switch (sw->get_type()) {
+        case SwitchType::LEARN:
+            this->learn_switch_ = sw;
+            break;
+        case SwitchType::TOGGLE_ONLY:
+            this->toggle_only_switch_ = sw;
+            break;
+        }
+    }
+
+    void GDOComponent::set_motion_state(gdo_motion_state_t state) {
+        if (this->motion_sensor_ != nullptr) {
+            this->motion_sensor_->publish(state == GDO_MOTION_STATE_DETECTED);
+        }
+    }
+
+    void GDOComponent::set_obstruction(gdo_obstruction_state_t state) {
+        if (this->obstruction_sensor_ != nullptr) {
+            this->obstruction_sensor_->publish(state == GDO_OBSTRUCTION_STATE_OBSTRUCTED);
+        }
+    }
+
+    void GDOComponent::set_button_state(gdo_button_state_t state) {
+        if (state == GDO_BUTTON_STATE_PRESSED) {
+            this->button_triggered_ = true;
+            if (this->door_ != nullptr) {
+                this->door_->cancel_pre_close_warning();
+            }
+        }
+
+        if (this->button_sensor_ != nullptr) {
+            this->button_sensor_->publish(state == GDO_BUTTON_STATE_PRESSED);
+        }
+    }
+
+    void GDOComponent::set_motor_state(gdo_motor_state_t state) {
+        if (this->motor_sensor_ != nullptr) {
+            this->motor_sensor_->publish(state == GDO_MOTOR_STATE_ON);
+        }
+
+        if (state == GDO_MOTOR_STATE_ON) {
+            if (!this->button_triggered_ && !this->cover_triggered_ && this->wireless_remote_sensor_ != nullptr) {
+                this->wireless_remote_sensor_->publish(true);
+                this->set_timeout("wireless_remote_off", 500, [this]() {
+                    if (this->wireless_remote_sensor_ != nullptr) {
+                        this->wireless_remote_sensor_->publish(false);
+                    }
+                });
+            }
+            this->button_triggered_ = false;
+            this->cover_triggered_ = false;
+        }
+    }
+
+    void GDOComponent::set_battery_state(gdo_battery_state_t state) {
+        if (this->battery_sensor_ != nullptr && state != GDO_BATT_STATE_UNKNOWN) {
+            this->battery_sensor_->update_state(gdo_battery_state_to_string(state));
+        }
+    }
+
+    void GDOComponent::set_openings(uint16_t openings) {
+        if (this->openings_sensor_ != nullptr) {
+            this->openings_sensor_->update_state(openings);
+        }
+    }
+
+    void GDOComponent::set_paired_devices(const gdo_paired_device_t &paired_devices) {
+        if (this->paired_total_sensor_ != nullptr) {
+            this->paired_total_sensor_->update_state(paired_devices.total_all);
+        }
+        if (this->paired_remotes_sensor_ != nullptr) {
+            this->paired_remotes_sensor_->update_state(paired_devices.total_remotes);
+        }
+        if (this->paired_keypads_sensor_ != nullptr) {
+            this->paired_keypads_sensor_->update_state(paired_devices.total_keypads);
+        }
+        if (this->paired_wall_controls_sensor_ != nullptr) {
+            this->paired_wall_controls_sensor_->update_state(paired_devices.total_wall_controls);
+        }
+        if (this->paired_accessories_sensor_ != nullptr) {
+            this->paired_accessories_sensor_->update_state(paired_devices.total_accessories);
+        }
+    }
+
+    void GDOComponent::sync_toggle_only_() {
+        bool toggle_only = this->status_.toggle_only;
+        if (this->toggle_only_switch_ != nullptr) {
+            this->toggle_only_switch_->set_control_function([this](bool state) {
+                this->status_.toggle_only = state;
+                if (this->door_ != nullptr) {
+                    this->door_->set_toggle_only(state);
+                }
+                if (this->initialized_) {
+                    gdo_set_toggle_only(state);
+                }
+            });
+            toggle_only = this->toggle_only_switch_->state;
+        }
+
+        this->status_.toggle_only = toggle_only;
+        if (this->door_ != nullptr) {
+            this->door_->set_toggle_only(toggle_only);
+        }
+        if (this->initialized_) {
+            gdo_set_toggle_only(toggle_only);
+        }
+    }
+
+    void GDOComponent::start_if_ready_() {
+        if (!this->initialized_ || this->started_ || !this->start_requested_) {
+            return;
+        }
+
+        const auto err = gdo_start(gdo_event_handler, this);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to start secplus GDO: %s", esp_err_to_name(err));
+            return;
+        }
+
+        this->started_ = true;
+        ESP_LOGI(TAG, "secplus GDO started");
+    }
+
+    void GDOComponent::setup() {
+        this->status_ = {};
+
+        // Initialize the driver first so child entities can restore saved preferences before we start it.
         gdo_config_t gdo_conf = {
             .uart_num = UART_NUM_1,
             .obst_from_status = true,
             .invert_uart = true,
-            .uart_tx_pin = (gpio_num_t)GDO_UART_TX_PIN,
-            .uart_rx_pin = (gpio_num_t)GDO_UART_RX_PIN,
-            .obst_in_pin = (gpio_num_t)-1,
+            .uart_tx_pin = (gpio_num_t) GDO_UART_TX_PIN,
+            .uart_rx_pin = (gpio_num_t) GDO_UART_RX_PIN,
+            .obst_in_pin = (gpio_num_t) -1,
         };
 
-        gdo_init(&gdo_conf);
-        gdo_get_status(&this->status_);
-        if (this->start_gdo_) {
-            gdo_start(gdo_event_handler, this);
-            ESP_LOGI(TAG, "secplus GDO started!");
-        } else {
-            // check every 500ms for readiness before starting GDO
-            this->set_interval("gdo_start", 500, [this]() {
-                if (this->start_gdo_) {
-                    gdo_start(gdo_event_handler, this);
-                    ESP_LOGI(TAG, "secplus GDO started!");
-                    this->cancel_interval("gdo_start");
-                }
-            });
-
+        const auto init_err = gdo_init(&gdo_conf);
+        if (init_err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to initialize secplus GDO: %s", esp_err_to_name(init_err));
+            this->mark_failed();
+            return;
         }
+
+        this->initialized_ = true;
+
+        const auto status_err = gdo_get_status(&this->status_);
+        if (status_err != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to load initial GDO status: %s", esp_err_to_name(status_err));
+        }
+
+        this->sync_toggle_only_();
+        this->defer([this]() { this->start_if_ready_(); });
     }
 
     void GDOComponent::dump_config() {
-        ESP_LOGCONFIG(TAG, "Setting up secplus GDO ...");
+        ESP_LOGCONFIG(TAG, "secplus GDO:");
+        ESP_LOGCONFIG(TAG, "  UART TX pin: %d", GDO_UART_TX_PIN);
+        ESP_LOGCONFIG(TAG, "  UART RX pin: %d", GDO_UART_RX_PIN);
+        ESP_LOGCONFIG(TAG, "  Initialized: %s", YESNO(this->initialized_));
+        ESP_LOGCONFIG(TAG, "  Start requested: %s", YESNO(this->start_requested_));
+        ESP_LOGCONFIG(TAG, "  Started: %s", YESNO(this->started_));
+        ESP_LOGCONFIG(TAG, "  Cover registered: %s", YESNO(this->door_ != nullptr));
+        ESP_LOGCONFIG(TAG, "  Light registered: %s", YESNO(this->light_ != nullptr));
+        ESP_LOGCONFIG(TAG, "  Lock registered: %s", YESNO(this->lock_ != nullptr));
+        ESP_LOGCONFIG(TAG, "  Protocol select registered: %s", YESNO(this->protocol_select_ != nullptr));
+        ESP_LOGCONFIG(TAG, "  Toggle-only switch registered: %s", YESNO(this->toggle_only_switch_ != nullptr));
+        ESP_LOGCONFIG(TAG, "  Learn switch registered: %s", YESNO(this->learn_switch_ != nullptr));
+    }
+
+    void GDOComponent::on_shutdown() {
+        if (!this->initialized_) {
+            return;
+        }
+
+        const auto err = gdo_deinit();
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to deinitialize secplus GDO: %s", esp_err_to_name(err));
+            return;
+        }
+
+        this->initialized_ = false;
+        this->started_ = false;
     }
 
     void GDOComponent::set_sync_state(bool synced) {
-        if (this->door_) {
+        this->status_.synced = synced;
+
+        if (this->door_ != nullptr) {
             this->door_->set_sync_state(synced);
         }
 
-        if (this->light_) {
+        if (this->light_ != nullptr) {
             this->light_->set_sync_state(synced);
         }
 
-        if (this->lock_) {
+        if (this->lock_ != nullptr) {
             this->lock_->set_sync_state(synced);
         }
 
-        if (this->f_sync) {
-            this->f_sync(synced);
+        if (this->sync_sensor_ != nullptr) {
+            this->sync_sensor_->publish(synced);
         }
     }
 
@@ -181,15 +443,15 @@ namespace secplus_gdo {
 extern "C" {
 #include "hal/gpio_hal.h"
 
-void __real_esp_panic_handler(void*);
+void __real_esp_panic_handler(void *);
 
-void __wrap_esp_panic_handler(void* info) {
+void __wrap_esp_panic_handler(void *info) {
     esp_rom_printf("PANIC: DISABLING GDO UART TX PIN!\n");
-    PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[(gpio_num_t)GDO_UART_TX_PIN], PIN_FUNC_GPIO);
-    gpio_set_direction((gpio_num_t)GDO_UART_TX_PIN, GPIO_MODE_INPUT);
-    gpio_pulldown_en((gpio_num_t)GDO_UART_TX_PIN);
+    PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[(gpio_num_t) GDO_UART_TX_PIN], PIN_FUNC_GPIO);
+    gpio_set_direction((gpio_num_t) GDO_UART_TX_PIN, GPIO_MODE_INPUT);
+    gpio_pulldown_en((gpio_num_t) GDO_UART_TX_PIN);
 
     // Call the original panic handler
     __real_esp_panic_handler(info);
 }
-} //extern "C"
+} // extern "C"

--- a/components/secplus_gdo/secplus_gdo.h
+++ b/components/secplus_gdo/secplus_gdo.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024  Konnected Inc.
+ * Copyright (C) 2026  CircuitSetup
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/components/secplus_gdo/secplus_gdo.h
+++ b/components/secplus_gdo/secplus_gdo.h
@@ -17,143 +17,146 @@
 
 #pragma once
 
-#include "esphome/core/component.h"
-#include "number/gdo_number.h"
-#include "esphome/core/defines.h"
-#include "select/gdo_select.h"
-#include "switch/gdo_switch.h"
+#include "binary_sensor/gdo_binary_sensor.h"
 #include "cover/gdo_door.h"
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+#include "gdo.h"
 #include "light/gdo_light.h"
 #include "lock/gdo_lock.h"
-#include "gdo.h"
-#include <utility>
-#include <string>
+#include "number/gdo_number.h"
+#include "select/gdo_select.h"
+#include "sensor/gdo_sensor.h"
+#include "switch/gdo_switch.h"
+#include "text_sensor/gdo_text_sensor.h"
 
 namespace esphome {
 namespace secplus_gdo {
+
     class GDOComponent : public Component {
     public:
         void setup() override;
-        void loop() override {};
+        void loop() override {}
         void dump_config() override;
-        void on_shutdown() override { gdo_deinit(); }
-        void start_gdo() { start_gdo_ = true; }
+        void on_shutdown() override;
+        void start_gdo();
 
-        // Use Late priority so we do not start the GDO lib until all saved preferences are loaded
-        [[nodiscard]] float get_setup_priority() const override { return setup_priority::BEFORE_CONNECTION; }
+        // Initialize the driver early, then defer gdo_start() until child entities have restored preferences.
+        [[nodiscard]] float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
         void register_protocol_select(GDOSelect *select) { this->protocol_select_ = select; }
-        void set_protocol_state(gdo_protocol_type_t protocol) { if (this->protocol_select_) {
-            this->protocol_select_->update_state(protocol); }
-        }
-
-        void register_motion(std::function<void(bool)> &&f) { f_motion = std::move(f); }
-        void set_motion_state(gdo_motion_state_t state) { if (f_motion) { f_motion(state == GDO_MOTION_STATE_DETECTED); } }
-
-        void register_obstruction(std::function<void(bool)> &&f) { f_obstruction = std::move(f); }
-        void set_obstruction(gdo_obstruction_state_t state) {
-            if (f_obstruction) { f_obstruction(state == GDO_OBSTRUCTION_STATE_OBSTRUCTED); }
-        }
-
-        void register_button(std::function<void(bool)> &&f) { f_button = std::move(f); }
-        void set_button_state(gdo_button_state_t state) {
-            if (state == GDO_BUTTON_STATE_PRESSED)
-                button_triggered_ = true;
-            if (state == GDO_BUTTON_STATE_PRESSED && this->door_)
-                this->door_->cancel_pre_close_warning();
-            if (f_button)
-                f_button(state == GDO_BUTTON_STATE_PRESSED);
-        }
-
-        void register_motor(std::function<void(bool)> &&f) { f_motor = std::move(f); }
-        void set_motor_state(gdo_motor_state_t state) {
-            if (f_motor) {
-                f_motor(state == GDO_MOTOR_STATE_ON);
-            }
-            if (state == GDO_MOTOR_STATE_ON) {
-                if (!button_triggered_ && !cover_triggered_ && f_wireless_remote) {
-                    f_wireless_remote(true);
-                    this->set_timeout("wireless_remote_off", 500, [this]() {
-                        if (f_wireless_remote) {
-                            f_wireless_remote(false);
-                        }
-                    });
-                }
-                button_triggered_ = false;
-                cover_triggered_ = false;
+        void set_protocol_state(gdo_protocol_type_t protocol) {
+            if (this->protocol_select_ != nullptr) {
+                this->protocol_select_->update_state(protocol);
             }
         }
 
-        void register_wireless_remote(std::function<void(bool)> &&f) { f_wireless_remote = std::move(f); }
+        void register_binary_sensor(GDOBinarySensor *sensor);
+        void register_sensor(GDOStat *sensor);
+        void register_text_sensor(GDOTextSensor *sensor);
+        void register_number(GDONumber *num);
+        void register_switch(GDOSwitch *sw);
 
-        void notify_cover_command() { cover_triggered_ = true; }
+        void notify_cover_command() { this->cover_triggered_ = true; }
 
-        void register_sync(std::function<void(bool)> &&f) { f_sync = std::move(f); }
+        void set_motion_state(gdo_motion_state_t state);
+        void set_obstruction(gdo_obstruction_state_t state);
+        void set_button_state(gdo_button_state_t state);
+        void set_motor_state(gdo_motor_state_t state);
+        void set_battery_state(gdo_battery_state_t state);
+        void set_openings(uint16_t openings);
+        void set_paired_devices(const gdo_paired_device_t &paired_devices);
 
-        void register_battery(std::function<void(std::string)> &&f) { f_battery = std::move(f); }
-        void set_battery_state(gdo_battery_state_t state) {
-            if (f_battery && state != GDO_BATT_STATE_UNKNOWN) {
-                f_battery(gdo_battery_state_to_string(state));
+        void register_door(GDODoor *door) {
+            this->door_ = door;
+            if (door != nullptr) {
+                door->set_parent(this);
             }
         }
-
-        void register_openings(std::function<void(uint16_t)> &&f) { f_openings = std::move(f); }
-        void set_openings(uint16_t openings) { if (f_openings) { f_openings(openings); } }
-
-        void register_door(GDODoor *door) { this->door_ = door; door->set_parent(this); }
-        void set_door_state(gdo_door_state_t state, float position) { if (this->door_) { this->door_->set_state(state, position); } }
+        void set_door_state(gdo_door_state_t state, float position) {
+            if (this->door_ != nullptr) {
+                this->door_->set_state(state, position);
+            }
+        }
 
         void register_light(GDOLight *light) { this->light_ = light; }
-        void set_light_state(gdo_light_state_t state) { if (this->light_) { this->light_->set_state(state); } }
-
-        void register_lock(GDOLock *lock) { this->lock_ = lock; }
-        void set_lock_state(gdo_lock_state_t state) { if (this->lock_) { this->lock_->set_state(state); } }
-
-        void register_learn(GDOSwitch *sw) { this->learn_switch_ = sw; }
-        void set_learn_state(gdo_learn_state_t state) { if (this->learn_switch_) {
-            this->learn_switch_->write_state(state == GDO_LEARN_STATE_ACTIVE); }
+        void set_light_state(gdo_light_state_t state) {
+            if (this->light_ != nullptr) {
+                this->light_->set_state(state);
+            }
         }
 
-        void register_open_duration(GDONumber* num) { open_duration_ = num; }
-        void set_open_duration(uint16_t ms ) { if (open_duration_) { open_duration_->update_state(ms); } }
+        void register_lock(GDOLock *lock) { this->lock_ = lock; }
+        void set_lock_state(gdo_lock_state_t state) {
+            if (this->lock_ != nullptr) {
+                this->lock_->set_state(state);
+            }
+        }
 
-        void register_close_duration(GDONumber* num) { close_duration_ = num; }
-        void set_close_duration(uint16_t ms ) { if (close_duration_) { close_duration_->update_state(ms); } }
+        void set_learn_state(gdo_learn_state_t state) {
+            if (this->learn_switch_ != nullptr) {
+                this->learn_switch_->publish_state_from_device(state == GDO_LEARN_STATE_ACTIVE);
+            }
+        }
 
-        void register_client_id(GDONumber* num) { client_id_ = num; }
-        void set_client_id(uint32_t num) { if (client_id_) { client_id_->update_state(num); } }
-
-        void register_rolling_code(GDONumber* num) { rolling_code_ = num; }
-        void set_rolling_code(uint32_t num) { if (rolling_code_) { rolling_code_->update_state(num); } }
-
-        void register_toggle_only(GDOSwitch *sw) { this->toggle_only_switch_ = sw; }
+        void set_open_duration(uint16_t ms) {
+            if (this->open_duration_ != nullptr) {
+                this->open_duration_->update_state(ms);
+            }
+        }
+        void set_close_duration(uint16_t ms) {
+            if (this->close_duration_ != nullptr) {
+                this->close_duration_->update_state(ms);
+            }
+        }
+        void set_client_id(uint32_t num) {
+            if (this->client_id_ != nullptr) {
+                this->client_id_->update_state(num);
+            }
+        }
+        void set_rolling_code(uint32_t num) {
+            if (this->rolling_code_ != nullptr) {
+                this->rolling_code_->update_state(num);
+            }
+        }
 
         void set_sync_state(bool synced);
 
     protected:
-        gdo_status_t                                 status_{};
-        std::function<void(uint16_t)>                f_openings{nullptr};
-        std::function<void(bool)>                    f_motion{nullptr};
-        std::function<void(bool)>                    f_obstruction{nullptr};
-        std::function<void(bool)>                    f_button{nullptr};
-        std::function<void(bool)>                    f_motor{nullptr};
-        std::function<void(bool)>                    f_wireless_remote{nullptr};
-        std::function<void(bool)>                    f_sync{nullptr};
-        GDODoor*                                     door_{nullptr};
-        GDOLight*                                    light_{nullptr};
-        GDOLock*                                     lock_{nullptr};
-        GDONumber*                                   open_duration_{nullptr};
-        GDONumber*                                   close_duration_{nullptr};
-        GDONumber*                                   client_id_{nullptr};
-        GDONumber*                                   rolling_code_{nullptr};
-        GDOSelect*                                   protocol_select_{nullptr};
-        GDOSwitch*                                   learn_switch_{nullptr};
-        GDOSwitch*                                   toggle_only_switch_{nullptr};
-        bool                                         start_gdo_{false};
-        bool                                         cover_triggered_{false};
-        bool                                         button_triggered_{false};
-        std::function<void(std::string)>             f_battery{nullptr};
+        void sync_toggle_only_();
+        void start_if_ready_();
+
+        gdo_status_t      status_{};
+        GDOBinarySensor  *motion_sensor_{nullptr};
+        GDOBinarySensor  *obstruction_sensor_{nullptr};
+        GDOBinarySensor  *motor_sensor_{nullptr};
+        GDOBinarySensor  *button_sensor_{nullptr};
+        GDOBinarySensor  *sync_sensor_{nullptr};
+        GDOBinarySensor  *wireless_remote_sensor_{nullptr};
+        GDODoor          *door_{nullptr};
+        GDOLight         *light_{nullptr};
+        GDOLock          *lock_{nullptr};
+        GDOTextSensor    *battery_sensor_{nullptr};
+        GDOStat          *openings_sensor_{nullptr};
+        GDOStat          *paired_total_sensor_{nullptr};
+        GDOStat          *paired_remotes_sensor_{nullptr};
+        GDOStat          *paired_keypads_sensor_{nullptr};
+        GDOStat          *paired_wall_controls_sensor_{nullptr};
+        GDOStat          *paired_accessories_sensor_{nullptr};
+        GDONumber        *open_duration_{nullptr};
+        GDONumber        *close_duration_{nullptr};
+        GDONumber        *client_id_{nullptr};
+        GDONumber        *rolling_code_{nullptr};
+        GDOSelect        *protocol_select_{nullptr};
+        GDOSwitch        *learn_switch_{nullptr};
+        GDOSwitch        *toggle_only_switch_{nullptr};
+        bool              initialized_{false};
+        bool              start_requested_{true};
+        bool              started_{false};
+        bool              cover_triggered_{false};
+        bool              button_triggered_{false};
 
     }; // GDOComponent
+
 } // namespace secplus_gdo
 } // namespace esphome

--- a/components/secplus_gdo/select/__init__.py
+++ b/components/secplus_gdo/select/__init__.py
@@ -1,9 +1,9 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import select
-from esphome.const import CONF_ID, CONF_INITIAL_OPTION
+from esphome.const import CONF_INITIAL_OPTION
 
-from .. import CONF_SECPLUS_GDO_ID, SECPLUS_GDO, SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns
+from .. import CONF_SECPLUS_GDO_ID, SECPLUS_GDO, secplus_gdo_ns, validate_cpp_symbol_id
 
 DEPENDENCIES = ["secplus_gdo"]
 
@@ -11,20 +11,21 @@ GDOSelect = secplus_gdo_ns.class_("GDOSelect", select.Select, cg.Component)
 
 CONF_PROTOCOL_SELECT_OPTIONS = ["auto", "security+1.0", "security+2.0", "security+1.0 with smart panel"]
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
     select.select_schema(GDOSelect)
     .extend(
         {
-            cv.GenerateID(CONF_SECPLUS_GDO_ID): cv.use_id(SECPLUS_GDO),
+            cv.Required(CONF_SECPLUS_GDO_ID): cv.use_id(SECPLUS_GDO),
             cv.Optional(CONF_INITIAL_OPTION, "auto"): cv.one_of(*CONF_PROTOCOL_SELECT_OPTIONS, lower=True),
         }
-    )
-    .extend(SECPLUS_GDO_CONFIG_SCHEMA)
+    ),
+    validate_cpp_symbol_id,
 )
 
+
 async def to_code(config):
-    s = await select.new_select(config, options=CONF_PROTOCOL_SELECT_OPTIONS)
-    await cg.register_component(s, config)
-    cg.add(s.set_initial_option(config[CONF_INITIAL_OPTION]))
+    select_var = await select.new_select(config, options=CONF_PROTOCOL_SELECT_OPTIONS)
+    await cg.register_component(select_var, config)
+    cg.add(select_var.set_initial_option(config[CONF_INITIAL_OPTION]))
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
-    cg.add(parent.register_protocol_select(s))
+    cg.add(parent.register_protocol_select(select_var))

--- a/components/secplus_gdo/select/gdo_select.h
+++ b/components/secplus_gdo/select/gdo_select.h
@@ -1,6 +1,7 @@
 /************************************
  *
  * Copyright (C) 2024 Konnected.io
+ * Copyright (C) 2026  CircuitSetup
  *
  * GNU GENERAL PUBLIC LICENSE
  ************************************/

--- a/components/secplus_gdo/select/gdo_select.h
+++ b/components/secplus_gdo/select/gdo_select.h
@@ -9,9 +9,8 @@
 
 #include "esphome/components/select/select.h"
 #include "esphome/core/component.h"
+#include "esphome/core/log.h"
 #include "esphome/core/preferences.h"
-#include "esphome/core/application.h"
-#include "../secplus_gdo.h"
 #include "gdo.h"
 
 namespace esphome {
@@ -19,6 +18,10 @@ namespace secplus_gdo {
 
     class GDOSelect : public select::Select, public Component {
     public:
+        void dump_config() override {
+            ESP_LOGCONFIG(TAG, "GDO select initial option: %s", this->initial_option_.c_str());
+        }
+
         void setup() override {
             std::string value;
             size_t index;
@@ -31,7 +34,7 @@ namespace secplus_gdo {
                 value = this->at(index).value();
             }
 
-            this->control(value);
+            this->apply_option_(value, false);
         }
 
         void set_initial_option(const std::string &initial_option) { this->initial_option_ = initial_option; }
@@ -39,9 +42,9 @@ namespace secplus_gdo {
         void update_state(gdo_protocol_type_t protocol) {
             if (this->has_index(protocol)) {
                 std::string value = this->at(protocol).value();
-                auto current_option = this->current_option();
                 if (this->has_state() && value != this->current_option()) {
-                    this->pref_.save(&protocol);
+                    const auto index = static_cast<size_t>(protocol);
+                    this->pref_.save(&index);
                 }
 
                 this->publish_state(value);
@@ -50,19 +53,35 @@ namespace secplus_gdo {
 
     protected:
         void control(const std::string &value) override {
+            this->apply_option_(value, true);
+        }
+
+        void apply_option_(const std::string &value, bool save_preference) {
             auto idx = this->index_of(value);
-            if (idx.has_value()) {
-                gdo_protocol_type_t protocol = static_cast<gdo_protocol_type_t>(idx.value());
-                this->update_state(protocol);
-                if (gdo_set_protocol(protocol) != ESP_OK) {
-                    vTaskDelay(pdMS_TO_TICKS(100));
-                    App.safe_reboot();
-                }
+            if (!idx.has_value()) {
+                ESP_LOGE(TAG, "Unsupported protocol option: %s", value.c_str());
+                return;
             }
+
+            gdo_protocol_type_t protocol = static_cast<gdo_protocol_type_t>(idx.value());
+            const auto err = gdo_set_protocol(protocol);
+            const bool unchanged = this->has_state() && value == this->current_option();
+            if (err != ESP_OK && !(unchanged && err == ESP_ERR_INVALID_STATE)) {
+                ESP_LOGE(TAG, "Failed to set protocol to %s: %s", value.c_str(), esp_err_to_name(err));
+                return;
+            }
+
+            if (save_preference) {
+                const auto index = static_cast<size_t>(idx.value());
+                this->pref_.save(&index);
+            }
+
+            this->publish_state(value);
         }
 
         std::string initial_option_;
         ESPPreferenceObject pref_;
+        static constexpr const char *TAG = "gdo.select";
     };
 
 } // namespace secplus_gdo

--- a/components/secplus_gdo/sensor/__init__.py
+++ b/components/secplus_gdo/sensor/__init__.py
@@ -39,7 +39,7 @@ TYPES = {
 }
 
 CONFIG_SCHEMA = cv.All(
-    sensor.sensor_schema(GDOStat)
+    sensor.sensor_schema(GDOStat, accuracy_decimals=0)
     .extend(
         {
             cv.Required(CONF_TYPE): cv.enum(TYPES, lower=True),

--- a/components/secplus_gdo/sensor/__init__.py
+++ b/components/secplus_gdo/sensor/__init__.py
@@ -22,7 +22,7 @@ import esphome.config_validation as cv
 from esphome.components import sensor
 from esphome.const import CONF_ID
 
-from .. import SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, CONF_SECPLUS_GDO_ID
+from .. import CONF_SECPLUS_GDO_ID, SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, validate_cpp_symbol_id
 
 DEPENDENCIES = ["secplus_gdo"]
 
@@ -30,23 +30,23 @@ GDOStat = secplus_gdo_ns.class_("GDOStat", sensor.Sensor, cg.Component)
 
 CONF_TYPE = "type"
 TYPES = {
-    "openings": "register_openings",
-    "paired_devices_total": "register_paired_total",
-    "paired_devices_remotes": "register_paired_remotes",
-    "paired_devices_keypads": "register_paired_keypads",
-    "paired_devices_wall_controls": "register_paired_wall_controls",
-    "paired_devices_accessories":"register_paired_accessories",
+    "openings": 0,
+    "paired_devices_total": 1,
+    "paired_devices_remotes": 2,
+    "paired_devices_keypads": 3,
+    "paired_devices_wall_controls": 4,
+    "paired_devices_accessories": 5,
 }
 
-
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
     sensor.sensor_schema(GDOStat)
     .extend(
         {
             cv.Required(CONF_TYPE): cv.enum(TYPES, lower=True),
         }
     )
-    .extend(SECPLUS_GDO_CONFIG_SCHEMA)
+    .extend(SECPLUS_GDO_CONFIG_SCHEMA),
+    validate_cpp_symbol_id,
 )
 
 
@@ -55,6 +55,5 @@ async def to_code(config):
     await sensor.register_sensor(var, config)
     await cg.register_component(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
-    fcall = str(parent) + "->" + str(TYPES[config[CONF_TYPE]])
-    text = fcall + "(std::bind(&" + str(GDOStat) + "::publish_state," + str(config[CONF_ID]) + ",std::placeholders::_1))"
-    cg.add((cg.RawExpression(text)))
+    cg.add(var.set_type(TYPES[config[CONF_TYPE]]))
+    cg.add(parent.register_sensor(var))

--- a/components/secplus_gdo/sensor/gdo_sensor.h
+++ b/components/secplus_gdo/sensor/gdo_sensor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024  Konnected Inc.
+ * Copyright (C) 2026  CircuitSetup
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/components/secplus_gdo/sensor/gdo_sensor.h
+++ b/components/secplus_gdo/sensor/gdo_sensor.h
@@ -15,15 +15,56 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-# pragma once
+#pragma once
 
-#include "esphome/core/component.h"
+#include <cstdint>
+
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace secplus_gdo {
 
-class GDOStat : public sensor::Sensor, public Component {};
+enum class GDOStatType : uint8_t {
+    OPENINGS = 0,
+    PAIRED_DEVICES_TOTAL,
+    PAIRED_DEVICES_REMOTES,
+    PAIRED_DEVICES_KEYPADS,
+    PAIRED_DEVICES_WALL_CONTROLS,
+    PAIRED_DEVICES_ACCESSORIES,
+};
+
+class GDOStat : public sensor::Sensor, public Component {
+public:
+    void dump_config() override { ESP_LOGCONFIG(TAG, "GDO sensor type: %s", this->type_to_string_()); }
+    void set_type(uint8_t type) { this->type_ = static_cast<GDOStatType>(type); }
+    GDOStatType get_type() const { return this->type_; }
+    void update_state(uint32_t value) { this->publish_state(value); }
+
+protected:
+    const char *type_to_string_() const {
+        switch (this->type_) {
+        case GDOStatType::OPENINGS:
+            return "openings";
+        case GDOStatType::PAIRED_DEVICES_TOTAL:
+            return "paired_devices_total";
+        case GDOStatType::PAIRED_DEVICES_REMOTES:
+            return "paired_devices_remotes";
+        case GDOStatType::PAIRED_DEVICES_KEYPADS:
+            return "paired_devices_keypads";
+        case GDOStatType::PAIRED_DEVICES_WALL_CONTROLS:
+            return "paired_devices_wall_controls";
+        case GDOStatType::PAIRED_DEVICES_ACCESSORIES:
+            return "paired_devices_accessories";
+        default:
+            return "unknown";
+        }
+    }
+
+    GDOStatType type_{GDOStatType::OPENINGS};
+    static constexpr const char *TAG = "gdo.sensor";
+};
 
 } // namespace secplus_gdo
 } // namespace esphome

--- a/components/secplus_gdo/switch/__init__.py
+++ b/components/secplus_gdo/switch/__init__.py
@@ -3,7 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import switch
 from esphome.const import CONF_ID
 
-from .. import SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, CONF_SECPLUS_GDO_ID
+from .. import CONF_SECPLUS_GDO_ID, SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, validate_cpp_symbol_id
 
 DEPENDENCIES = ["secplus_gdo"]
 
@@ -11,19 +11,19 @@ GDOSwitch = secplus_gdo_ns.class_("GDOSwitch", switch.Switch, cg.Component)
 
 CONF_TYPE = "type"
 TYPES = {
-    "learn": "register_learn",
-    "toggle_only": "register_toggle_only",
+    "learn": 0,
+    "toggle_only": 1,
 }
 
-
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
     switch.switch_schema(GDOSwitch)
     .extend(
         {
             cv.Required(CONF_TYPE): cv.enum(TYPES, lower=True),
         }
     )
-    .extend(SECPLUS_GDO_CONFIG_SCHEMA)
+    .extend(SECPLUS_GDO_CONFIG_SCHEMA),
+    validate_cpp_symbol_id,
 )
 
 
@@ -32,8 +32,5 @@ async def to_code(config):
     await switch.register_switch(var, config)
     await cg.register_component(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
-    fcall = str(parent) + "->" + str(TYPES[config[CONF_TYPE]])
-    text = fcall + "(" + str(var) + ")"
-    cg.add((cg.RawExpression(text)))
-    text = "secplus_gdo::SwitchType::" + str(config[CONF_TYPE]).upper()
-    cg.add(var.set_type(cg.RawExpression(text)))
+    cg.add(var.set_type(TYPES[config[CONF_TYPE]]))
+    cg.add(parent.register_switch(var))

--- a/components/secplus_gdo/switch/gdo_switch.h
+++ b/components/secplus_gdo/switch/gdo_switch.h
@@ -7,22 +7,27 @@
 
 #pragma once
 
+#include <cstdint>
+#include <utility>
+
 #include "esphome/components/switch/switch.h"
-#include "esphome/core/preferences.h"
 #include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/core/preferences.h"
 #include "gdo.h"
 
 namespace esphome {
 namespace secplus_gdo {
 
-    enum SwitchType {
-        LEARN,
-        TOGGLE_ONLY,
+    enum class SwitchType : uint8_t {
+        LEARN = 0,
+        TOGGLE_ONLY = 1,
     };
 
     class GDOSwitch : public switch_::Switch, public Component {
     public:
-        void dump_config() override {}
+        void dump_config() override { ESP_LOGCONFIG(TAG, "GDO switch type: %s", this->type_to_string_()); }
+
         void setup() override {
             bool value = false;
             this->pref_ = this->make_entity_preference<bool>();
@@ -30,7 +35,14 @@ namespace secplus_gdo {
                 value = false;
             }
 
-            this->write_state(value);
+            if (this->type_ == SwitchType::TOGGLE_ONLY) {
+                if (this->f_control) {
+                    this->f_control(value);
+                }
+                this->publish_state(value);
+            } else {
+                this->publish_state(false);
+            }
         }
 
         void write_state(bool state) override {
@@ -41,28 +53,47 @@ namespace secplus_gdo {
             if (this->type_ == SwitchType::TOGGLE_ONLY) {
                 if (this->f_control) {
                     this->f_control(state);
-                    this->pref_.save(&state);
                 }
+                this->pref_.save(&state);
+                this->publish_state(state);
+                return;
             }
 
-            if (this->type_ == SwitchType::LEARN) {
-                if (state) {
-                    gdo_activate_learn();
-                } else {
-                    gdo_deactivate_learn();
-                }
+            const auto err = state ? gdo_activate_learn() : gdo_deactivate_learn();
+            if (err != ESP_OK) {
+                ESP_LOGE(TAG, "Failed to set %s: %s", this->type_to_string_(), esp_err_to_name(err));
+                return;
             }
 
             this->publish_state(state);
         }
 
-        void set_type(SwitchType type) { this->type_ = type; }
-        void set_control_function(std::function<void(bool)> f) { f_control = f; }
+        void publish_state_from_device(bool state) {
+            if (state != this->state) {
+                this->publish_state(state);
+            }
+        }
+
+        void set_type(uint8_t type) { this->type_ = static_cast<SwitchType>(type); }
+        SwitchType get_type() const { return this->type_; }
+        void set_control_function(std::function<void(bool)> f) { this->f_control = std::move(f); }
 
     protected:
-        SwitchType                type_{SwitchType::LEARN};
+        const char *type_to_string_() const {
+            switch (this->type_) {
+            case SwitchType::LEARN:
+                return "learn";
+            case SwitchType::TOGGLE_ONLY:
+                return "toggle_only";
+            default:
+                return "unknown";
+            }
+        }
+
+        SwitchType               type_{SwitchType::LEARN};
         std::function<void(bool)> f_control{nullptr};
         ESPPreferenceObject       pref_;
+        static constexpr const char *TAG = "gdo.switch";
     };
 
 } // namespace secplus_gdo

--- a/components/secplus_gdo/switch/gdo_switch.h
+++ b/components/secplus_gdo/switch/gdo_switch.h
@@ -1,6 +1,7 @@
 /************************************
  *
  * Copyright (C) 2024 Konnected.io
+ * Copyright (C) 2026  CircuitSetup
  *
  * GNU GENERAL PUBLIC LICENSE
  ************************************/

--- a/components/secplus_gdo/text_sensor/__init__.py
+++ b/components/secplus_gdo/text_sensor/__init__.py
@@ -1,6 +1,6 @@
 """
 /*
- * Copyright (C) 2025 CircuitSetup
+ * Copyright (C) 2024  Konnected Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,46 +15,40 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-"""
+ """
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import text_sensor
 from esphome.const import CONF_ID
 
-from .. import SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, CONF_SECPLUS_GDO_ID
+from .. import CONF_SECPLUS_GDO_ID, SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, validate_cpp_symbol_id
 
 DEPENDENCIES = ["secplus_gdo"]
 
-GDOTextSensor = secplus_gdo_ns.class_(
-    "GDOTextSensor", text_sensor.TextSensor, cg.Component
-)
+GDOTextSensor = secplus_gdo_ns.class_("GDOTextSensor", text_sensor.TextSensor, cg.Component)
 
 CONF_TYPE = "type"
 TYPES = {
-    "battery": "register_battery",
+    "battery": 0,
 }
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
     text_sensor.text_sensor_schema(GDOTextSensor)
     .extend(
         {
             cv.Required(CONF_TYPE): cv.enum(TYPES, lower=True),
         }
     )
-    .extend(SECPLUS_GDO_CONFIG_SCHEMA)
+    .extend(SECPLUS_GDO_CONFIG_SCHEMA),
+    validate_cpp_symbol_id,
 )
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await text_sensor.register_text_sensor(var, config)
     await cg.register_component(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
-    fcall = str(parent) + "->" + str(TYPES[config[CONF_TYPE]])
-    text = (
-        fcall
-        + "([=](std::string value) { "
-        + str(config[CONF_ID])
-        + "->publish_state(value); })"
-    )
-    cg.add(cg.RawExpression(text))
+    cg.add(var.set_type(TYPES[config[CONF_TYPE]]))
+    cg.add(parent.register_text_sensor(var))

--- a/components/secplus_gdo/text_sensor/gdo_text_sensor.h
+++ b/components/secplus_gdo/text_sensor/gdo_text_sensor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 CircuitSetup
+ * Copyright (C) 2024  Konnected Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,13 +17,40 @@
 
 #pragma once
 
-#include "esphome/core/component.h"
+#include <cstdint>
+#include <string>
+
 #include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace secplus_gdo {
 
-class GDOTextSensor : public text_sensor::TextSensor, public Component {};
+enum class GDOTextSensorType : uint8_t {
+    BATTERY = 0,
+};
+
+class GDOTextSensor : public text_sensor::TextSensor, public Component {
+public:
+    void dump_config() override { ESP_LOGCONFIG(TAG, "GDO text sensor type: %s", this->type_to_string_()); }
+    void set_type(uint8_t type) { this->type_ = static_cast<GDOTextSensorType>(type); }
+    GDOTextSensorType get_type() const { return this->type_; }
+    void update_state(const std::string &value) { this->publish_state(value); }
+
+protected:
+    const char *type_to_string_() const {
+        switch (this->type_) {
+        case GDOTextSensorType::BATTERY:
+            return "battery";
+        default:
+            return "unknown";
+        }
+    }
+
+    GDOTextSensorType type_{GDOTextSensorType::BATTERY};
+    static constexpr const char *TAG = "gdo.text_sensor";
+};
 
 } // namespace secplus_gdo
 } // namespace esphome

--- a/components/secplus_gdo/text_sensor/gdo_text_sensor.h
+++ b/components/secplus_gdo/text_sensor/gdo_text_sensor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024  Konnected Inc.
+ * Copyright (C) 2026  CircuitSetup
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/packages/buzzer-rtttl.yaml
+++ b/packages/buzzer-rtttl.yaml
@@ -21,9 +21,9 @@ script:
       - rtttl.play: $error_tone
 
 api:
-  services:      
-    # Call the play_rtttl service to play any RTTTL song in the garage
-    - service: play_rtttl
+  actions:
+    # Call the play_rtttl action to play any RTTTL song in the garage
+    - action: play_rtttl
       variables:
         song_str: string
       then:

--- a/packages/core-esp32-s3.yaml
+++ b/packages/core-esp32-s3.yaml
@@ -25,7 +25,7 @@ esp32:
     type: esp-idf
     version: recommended
     sdkconfig_options:
-      CONFIG_LWIP_MAX_SOCKETS: "16"
+      CONFIG_LWIP_MAX_SOCKETS: "17"
 
 substitutions:
   status_led_inverted: "false"

--- a/packages/core-esp32-s3.yaml
+++ b/packages/core-esp32-s3.yaml
@@ -65,3 +65,5 @@ button:
 ota:
   - platform: esphome
     id: circuitsetup_ota
+    # Recommended for shared networks:
+    # password: !secret ota_password

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -44,6 +44,7 @@ sensor:
     type: paired_devices_total
     name: Paired Devices
     accuracy_decimals: 0
+    icon: mdi:devices
     entity_category: diagnostic
   - platform: secplus_gdo
     secplus_gdo_id: cs_gdo
@@ -51,6 +52,7 @@ sensor:
     type: paired_devices_remotes
     name: Paired Remotes
     accuracy_decimals: 0
+    icon: mdi:remote
     entity_category: diagnostic
   - platform: secplus_gdo
     secplus_gdo_id: cs_gdo
@@ -58,6 +60,7 @@ sensor:
     type: paired_devices_keypads
     name: Paired Keypads
     accuracy_decimals: 0
+    icon: mdi:dialpad
     entity_category: diagnostic
   - platform: secplus_gdo
     secplus_gdo_id: cs_gdo
@@ -65,6 +68,7 @@ sensor:
     type: paired_devices_wall_controls
     name: Paired Wall Controls
     accuracy_decimals: 0
+    icon: mdi:gesture-tap-button
     entity_category: diagnostic
   - platform: secplus_gdo
     secplus_gdo_id: cs_gdo
@@ -72,6 +76,7 @@ sensor:
     type: paired_devices_accessories
     name: Paired Accessories
     accuracy_decimals: 0
+    icon: mdi:puzzle-outline
     entity_category: diagnostic
 
 text_sensor:
@@ -160,12 +165,9 @@ button:
     id: reset_door_timings
     entity_category: config
     on_press:
-      - number.set:
-          id: gdo_open_duration
-          value: 0
-      - number.set:
-          id: gdo_close_duration
-          value: 0
+      - lambda: |-
+          id(gdo_open_duration).update_state(0);
+          id(gdo_close_duration).update_state(0);
       - button.press:
           id: restart_button
   - platform: template
@@ -179,9 +181,7 @@ button:
           uint32_t client_id = random_upper | 0x2908;
           ESP_LOGW("lambda","Re-syncing with Client ID: 0x%08X (%" PRIu32 ")", client_id, random_upper);
           id(gdo_client_id).update_state(client_id);
-      - number.set:
-          id: gdo_rolling_code
-          value: 0
+          id(gdo_rolling_code).update_state(0);
       - button.press:
           id: restart_button
 

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -34,7 +34,45 @@ sensor:
     type: openings
     name: $garage_openings_name
     unit_of_measurement: openings
+    accuracy_decimals: 0
+    state_class: total_increasing
     icon: mdi:open-in-app
+    entity_category: diagnostic
+  - platform: secplus_gdo
+    secplus_gdo_id: cs_gdo
+    id: gdo_paired_total
+    type: paired_devices_total
+    name: Paired Devices
+    accuracy_decimals: 0
+    entity_category: diagnostic
+  - platform: secplus_gdo
+    secplus_gdo_id: cs_gdo
+    id: gdo_paired_remotes
+    type: paired_devices_remotes
+    name: Paired Remotes
+    accuracy_decimals: 0
+    entity_category: diagnostic
+  - platform: secplus_gdo
+    secplus_gdo_id: cs_gdo
+    id: gdo_paired_keypads
+    type: paired_devices_keypads
+    name: Paired Keypads
+    accuracy_decimals: 0
+    entity_category: diagnostic
+  - platform: secplus_gdo
+    secplus_gdo_id: cs_gdo
+    id: gdo_paired_wall_controls
+    type: paired_devices_wall_controls
+    name: Paired Wall Controls
+    accuracy_decimals: 0
+    entity_category: diagnostic
+  - platform: secplus_gdo
+    secplus_gdo_id: cs_gdo
+    id: gdo_paired_accessories
+    type: paired_devices_accessories
+    name: Paired Accessories
+    accuracy_decimals: 0
+    entity_category: diagnostic
 
 text_sensor:
   - platform: secplus_gdo
@@ -43,6 +81,7 @@ text_sensor:
     name: $garage_battery_name
     type: battery
     icon: mdi:battery
+    entity_category: diagnostic
 
 lock:
   - platform: secplus_gdo
@@ -94,6 +133,7 @@ switch:
     secplus_gdo_id: cs_gdo
     name: Learn
     icon: mdi:plus-box
+    entity_category: config
   - platform: secplus_gdo
     id: gdo_toggle_only
     type: toggle_only
@@ -181,7 +221,3 @@ number:
     type: rolling_code
     mode: box
     internal: true
-
-wifi:
-  on_connect:
-    lambda: id(cs_gdo).start_gdo();

--- a/packages/wifi-esp32.yaml
+++ b/packages/wifi-esp32.yaml
@@ -4,6 +4,7 @@ wifi:
     - ble.disable:
   on_disconnect:
     - ble.enable:
+  power_save_mode: NONE
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
 


### PR DESCRIPTION
## Additions

### 1. Hardens `secplus_gdo` for current ESPHome behavior
- Reworks component startup/shutdown so the driver initializes more safely and starts in a more predictable order.
- Improves cover behavior around pre-close warning, cancel/stop flows, and unsynced operation.
- Adds stronger config-time validation for generated IDs and invalid pin reuse.
- Improves light and switch handling with better sync/error guards.
- Preserves the panic-wrapper and newer ESPHome compatibility fixes.

### 2. Exposes more useful opener diagnostics and state
- Adds support for battery reporting.
- Adds wireless-remote event reporting.
- Adds paired-device counts, including remotes, keypads, wall controls, accessories, and total paired devices.
- Improves state plumbing so these entities are easier to surface and more consistent for Home Assistant users.

### 3. Improves onboarding and customization documentation
- Rewrites the top-level README into a more task-oriented setup guide.
- Documents a clearer “starting point” path for users.
- Defines a safer customization surface for common edits.
- Expands the `secplus_gdo` component README with direct-component usage, supported entity types, reserved IDs, and local development guidance.

## User Impact

For CircuitSetup Security+ garage door users, this PR should make the firmware easier to adopt and safer to customize while also improving runtime behavior.

Most importantly, users get:
- more reliable `secplus_gdo` behavior on current ESPHome
- better handling of close warnings, stop/cancel flows, and unsynced states
- more visibility into opener state through battery, wireless-remote, and paired-device diagnostics
- clearer documentation for both quick-start use and deeper YAML customization

## Validation

- `python -m compileall components/secplus_gdo`
- `python -m esphome config circuitsetup-secplus-garage-door-opener.yaml`
- `python -m esphome config circuitsetup-gdo-dry-contact.yaml`

Both ESPHome config validations passed locally. The expected ESPHome warning about GPIO3 being a strapping pin was still present.