### PR TITLE
Fix Security+ rolling code recovery and diagnostic resync

### DIFF
--- a/circuitsetup-secplus-garage-door-opener.yaml
+++ b/circuitsetup-secplus-garage-door-opener.yaml
@@ -51,7 +51,7 @@ substitutions:
   name: circuitsetup-gdo
   friendly_name: Garage Door Opener
   project_name: circuitsetup.secplus-garage-door-opener
-  project_version: "1.5.3"
+  project_version: "1.5.4"
   garage_door_cover_name: Garage Door
   garage_light_name: Garage Light
   garage_openings_name: Garage Openings

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -424,6 +424,22 @@ namespace secplus_gdo {
 
         this->sync_toggle_only_();
         this->defer([this]() { this->start_if_ready_(); });
+        this->set_timeout("startup_secplus_status_log", 20000, []() {
+            gdo_status_t status{};
+            const auto err = gdo_get_status(&status);
+            if (err != ESP_OK) {
+                ESP_LOGW(TAG, "Failed to read startup Security+ status: %s", esp_err_to_name(err));
+                return;
+            }
+
+            if (status.protocol == GDO_PROTOCOL_SEC_PLUS_V2) {
+                ESP_LOGI(TAG,
+                         "Startup Security+ state: opener status: %s, gdolib diagnostic sync: %s, Client ID: %" PRIu32
+                         ", Rolling code: %" PRIu32,
+                         status.door != GDO_DOOR_STATE_UNKNOWN ? "received" : "not received",
+                         status.synced ? "complete" : "incomplete", status.client_id, status.rolling_code);
+            }
+        });
     }
 
     void GDOComponent::dump_config() {

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -41,7 +41,7 @@ namespace secplus_gdo {
         switch (event) {
         case GDO_CB_EVENT_SYNCED: {
             const bool has_opener_status = status->door != GDO_DOOR_STATE_UNKNOWN;
-            const bool rolling_code_accepted = has_opener_status || gdo->is_sync_state();
+            const bool rolling_code_accepted = has_opener_status;
             bool effective_synced = status->synced || rolling_code_accepted;
             ESP_LOGI(TAG, "Synced: %s, gdolib diagnostic sync: %s, protocol: %s",
                      effective_synced ? "true" : "false", status->synced ? "complete" : "incomplete",

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -28,6 +28,8 @@ namespace esphome {
 namespace secplus_gdo {
 
     constexpr char TAG[] = "secplus_gdo";
+    constexpr uint8_t ROLLING_CODE_ANCHOR_RETRIES = 3;
+    constexpr uint8_t MAX_DIAGNOSTIC_DRIVER_RESTARTS = 3;
 
     static void gdo_event_handler(const gdo_status_t *status, gdo_cb_event_t event, void *arg) {
         auto *gdo = static_cast<GDOComponent *>(arg);
@@ -49,8 +51,8 @@ namespace secplus_gdo {
             }
             if (status->protocol == GDO_PROTOCOL_SEC_PLUS_V2) {
                 ESP_LOGI(TAG, "Client ID: %" PRIu32 ", Rolling code: %" PRIu32, status->client_id, status->rolling_code);
-                if (status->synced) {
-                    // Save the last successful ClientID rolling code value to NVS for use on reboot.
+                if (status->synced || has_opener_status) {
+                    // Save the last rolling code value proven by the opener for use on reboot.
                     gdo->set_client_id(status->client_id);
                     gdo->set_rolling_code(status->rolling_code);
                 }
@@ -63,11 +65,18 @@ namespace secplus_gdo {
                              "advancing rolling code; restarting gdolib driver to retry diagnostic data sync");
                     gdo->schedule_diagnostic_data_resync();
                 } else {
-                    const auto next_rolling_code = gdo->next_rolling_code_search_value(status->rolling_code);
+                    bool rolling_code_search_advanced = false;
+                    const auto next_rolling_code =
+                        gdo->next_rolling_code_search_value(status->rolling_code, &rolling_code_search_advanced);
                     if (gdo_set_rolling_code(next_rolling_code) != ESP_OK) {
                         ESP_LOGE(TAG, "Failed to set rolling code");
                     } else {
-                        ESP_LOGI(TAG, "Rolling code search advanced to %" PRIu32 ", retrying sync", next_rolling_code);
+                        if (rolling_code_search_advanced) {
+                            ESP_LOGI(TAG, "Rolling code search advanced to %" PRIu32 ", retrying sync",
+                                     next_rolling_code);
+                        } else {
+                            ESP_LOGI(TAG, "Retrying rolling code anchor %" PRIu32, next_rolling_code);
+                        }
                         const auto err = gdo_sync();
                         if (err != ESP_OK) {
                             ESP_LOGE(TAG, "Failed to start resync: %s", esp_err_to_name(err));
@@ -409,6 +418,8 @@ namespace secplus_gdo {
         const auto status_err = gdo_get_status(&this->status_);
         if (status_err != ESP_OK) {
             ESP_LOGW(TAG, "Failed to load initial GDO status: %s", esp_err_to_name(status_err));
+        } else if (this->status_.rolling_code != 0) {
+            this->remember_rolling_code_(this->status_.rolling_code);
         }
 
         this->sync_toggle_only_();
@@ -450,12 +461,25 @@ namespace secplus_gdo {
         this->rolling_code_search_value_ = num;
         this->has_last_known_rolling_code_ = true;
         this->has_rolling_code_search_value_ = false;
+        this->rolling_code_anchor_retries_remaining_ = ROLLING_CODE_ANCHOR_RETRIES;
     }
 
-    uint32_t GDOComponent::next_rolling_code_search_value(uint32_t fallback) {
+    uint32_t GDOComponent::next_rolling_code_search_value(uint32_t fallback, bool *advanced) {
+        if (advanced != nullptr) {
+            *advanced = false;
+        }
+
         if (!this->has_last_known_rolling_code_) {
             this->last_known_rolling_code_ = fallback;
             this->has_last_known_rolling_code_ = true;
+            this->rolling_code_anchor_retries_remaining_ = ROLLING_CODE_ANCHOR_RETRIES;
+        }
+
+        if (this->rolling_code_anchor_retries_remaining_ > 0) {
+            this->rolling_code_search_value_ = this->last_known_rolling_code_;
+            this->has_rolling_code_search_value_ = true;
+            --this->rolling_code_anchor_retries_remaining_;
+            return this->rolling_code_search_value_;
         }
 
         const auto base =
@@ -463,6 +487,9 @@ namespace secplus_gdo {
         const auto next = base + 100;
         this->rolling_code_search_value_ = next;
         this->has_rolling_code_search_value_ = true;
+        if (advanced != nullptr) {
+            *advanced = true;
+        }
         return next;
     }
 
@@ -482,9 +509,11 @@ namespace secplus_gdo {
             return;
         }
 
-        if (this->diagnostic_driver_restart_attempted_) {
+        if (this->diagnostic_driver_restart_attempt_count_ >= MAX_DIAGNOSTIC_DRIVER_RESTARTS) {
             ESP_LOGW(TAG,
-                     "Diagnostic sync still incomplete after gdolib driver restart; waiting for external sync request");
+                     "Diagnostic sync still incomplete after %" PRIu8
+                     " gdolib driver restart attempts; waiting for external sync request",
+                     this->diagnostic_driver_restart_attempt_count_);
             return;
         }
 
@@ -517,13 +546,12 @@ namespace secplus_gdo {
 
         const auto client_id = status.client_id;
         const auto rolling_code = status.rolling_code;
+        ++this->diagnostic_driver_restart_attempt_count_;
         ESP_LOGW(TAG,
-                 "Restarting gdolib driver for diagnostic sync with Client ID: %" PRIu32
-                 ", Rolling code: %" PRIu32,
-                 client_id, rolling_code);
-
-        this->diagnostic_driver_restart_attempted_ = true;
-        this->set_sync_state(false);
+                 "Restarting gdolib driver for diagnostic sync attempt %" PRIu8
+                 "/%" PRIu8 " with Client ID: %" PRIu32 ", Rolling code: %" PRIu32,
+                 this->diagnostic_driver_restart_attempt_count_, MAX_DIAGNOSTIC_DRIVER_RESTARTS, client_id,
+                 rolling_code);
 
         const auto deinit_err = gdo_deinit();
         if (deinit_err != ESP_OK) {
@@ -534,7 +562,6 @@ namespace secplus_gdo {
 
         this->initialized_ = false;
         this->started_ = false;
-        this->status_ = {};
 
         const auto init_err = this->init_driver_();
         if (init_err != ESP_OK) {
@@ -573,7 +600,7 @@ namespace secplus_gdo {
     void GDOComponent::reset_diagnostic_resync_state() {
         this->cancel_timeout("diagnostic_driver_restart");
         this->diagnostic_driver_restart_pending_ = false;
-        this->diagnostic_driver_restart_attempted_ = false;
+        this->diagnostic_driver_restart_attempt_count_ = 0;
     }
 
     void GDOComponent::set_rolling_code(uint32_t num) {

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -477,18 +477,25 @@ namespace secplus_gdo {
     }
 
     void GDOComponent::schedule_diagnostic_driver_restart_() {
+        if (this->diagnostic_driver_restart_pending_) {
+            ESP_LOGD(TAG, "Diagnostic data resync already has a gdolib driver restart pending");
+            return;
+        }
+
         if (this->diagnostic_driver_restart_attempted_) {
             ESP_LOGW(TAG,
                      "Diagnostic sync still incomplete after gdolib driver restart; waiting for external sync request");
             return;
         }
 
-        this->diagnostic_driver_restart_attempted_ = true;
+        this->diagnostic_driver_restart_pending_ = true;
         this->set_timeout("diagnostic_driver_restart", 1000,
                           [this]() { this->restart_driver_for_diagnostic_sync_(); });
     }
 
     void GDOComponent::restart_driver_for_diagnostic_sync_() {
+        this->diagnostic_driver_restart_pending_ = false;
+
         if (!this->initialized_) {
             ESP_LOGD(TAG, "Skipping gdolib driver restart because secplus GDO is not initialized");
             return;
@@ -515,6 +522,7 @@ namespace secplus_gdo {
                  ", Rolling code: %" PRIu32,
                  client_id, rolling_code);
 
+        this->diagnostic_driver_restart_attempted_ = true;
         this->set_sync_state(false);
 
         const auto deinit_err = gdo_deinit();
@@ -563,6 +571,8 @@ namespace secplus_gdo {
     }
 
     void GDOComponent::reset_diagnostic_resync_state() {
+        this->cancel_timeout("diagnostic_driver_restart");
+        this->diagnostic_driver_restart_pending_ = false;
         this->diagnostic_driver_restart_attempted_ = false;
     }
 

--- a/components/secplus_gdo/secplus_gdo.h
+++ b/components/secplus_gdo/secplus_gdo.h
@@ -118,7 +118,7 @@ namespace secplus_gdo {
         void set_rolling_code(uint32_t num);
 
         bool is_sync_state() const { return this->status_.synced; }
-        uint32_t next_rolling_code_search_value(uint32_t fallback);
+        uint32_t next_rolling_code_search_value(uint32_t fallback, bool *advanced = nullptr);
         void schedule_diagnostic_data_resync();
         void reset_diagnostic_resync_state();
         void set_sync_state(bool synced);
@@ -163,7 +163,8 @@ namespace secplus_gdo {
         bool              has_last_known_rolling_code_{false};
         bool              has_rolling_code_search_value_{false};
         bool              diagnostic_driver_restart_pending_{false};
-        bool              diagnostic_driver_restart_attempted_{false};
+        uint8_t           diagnostic_driver_restart_attempt_count_{0};
+        uint8_t           rolling_code_anchor_retries_remaining_{0};
         uint32_t          last_known_rolling_code_{0};
         uint32_t          rolling_code_search_value_{0};
 

--- a/components/secplus_gdo/secplus_gdo.h
+++ b/components/secplus_gdo/secplus_gdo.h
@@ -162,6 +162,7 @@ namespace secplus_gdo {
         bool              button_triggered_{false};
         bool              has_last_known_rolling_code_{false};
         bool              has_rolling_code_search_value_{false};
+        bool              diagnostic_driver_restart_pending_{false};
         bool              diagnostic_driver_restart_attempted_{false};
         uint32_t          last_known_rolling_code_{0};
         uint32_t          rolling_code_search_value_{0};

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -179,7 +179,7 @@ button:
           // Generate random upper 16 bits, keep lower 16 bits as 0x2908
           uint32_t random_upper = (esp_random() & 0x7F7F) << 16;
           uint32_t client_id = random_upper | 0x2908;
-          ESP_LOGW("lambda","Re-syncing with Client ID: 0x%08X (%" PRIu32 ")", client_id, random_upper);
+          ESP_LOGW("lambda","Re-syncing with Client ID: 0x%08X (%" PRIu32 "), Rolling code: 0", client_id, random_upper);
           id(gdo_client_id).update_state(client_id);
           id(gdo_rolling_code).update_state(0);
       - button.press:


### PR DESCRIPTION
## Summary

This fixes the Security+ 2.0 recovery path when the opener accepts a rolling code but gdolib does not complete the diagnostic data sync for garage openings and paired-device counts. It also bumps the Security+ GDO project version to `1.5.4`.

## Root Cause

After a rolling code was accepted, gdolib could still report diagnostic sync as incomplete because openings or paired-device queries timed out. The component then restarted the gdolib driver once, but it cleared the component's own sync state and treated the one restart attempt as proof of acceptance. If that single diagnostic-only restart also timed out, the component stopped trying and left the Home Assistant diagnostic sensors missing until the manual Re-sync/reboot path ran.

On reboot or later recovery, the rolling-code search could also move straight to a `+100` search value instead of first retrying the last rolling code that had been proven by opener status. The final update also avoids using the component's previously synced state as proof of current rolling-code acceptance; a sync attempt now needs real opener status from gdolib before it is considered accepted.

## Changes

- Persist the client ID and rolling code when opener status proves that the rolling code was accepted, even if gdolib diagnostic sync is still incomplete.
- Retry the last known rolling-code anchor before advancing the search window.
- Treat opener status, not a stale local synced flag, as proof that the current rolling code is accepted.
- Preserve the component's accepted sync state across gdolib-only diagnostic restarts.
- Replace the one-shot diagnostic restart flag with a bounded restart counter, allowing up to three diagnostic-only gdolib restarts before giving up and waiting for an external sync request.
- Log Re-sync as staging rolling code `0`, and log a one-time post-boot Security+ state line showing actual client ID, rolling code, opener-status receipt, and gdolib diagnostic sync state.
- Bump `circuitsetup.secplus-garage-door-opener` to `1.5.4`.

## Validation

- `git diff --check -- components/secplus_gdo/secplus_gdo.cpp packages/secplus-gdo.yaml`
- `python -m esphome compile .esphome\diagnostic\circuitsetup-secplus-garage-door-opener-restore.yaml`
- `python -m esphome config circuitsetup-secplus-garage-door-opener.yaml`
- OTA uploaded the compiled firmware to `circuitsetup-gdo-f3edcc.local`
- Queried the live ESPHome API after OTA and confirmed:
  - firmware compile time `2026-05-27 09:21:37 -0400`
  - `Synced` is ON
  - `Garage Openings` is populated
  - paired-device totals are populated
- Captured the new delayed startup log showing actual post-boot state:
  - `Startup Security+ state: opener status: received, gdolib diagnostic sync: complete, Client ID: 541600008, Rolling code: 17`
- Temporarily forced the gdolib diagnostic restart path and confirmed it restarted gdolib, received `Openings`, received `Paired devices`, and completed diagnostic sync.

I did not force an invalid rolling-code state on the live opener; the rolling-code miss path was verified by code-path inspection after correcting the stale-local-sync shortcut.