### PR TITLE
Optimize ESPHome flash and close warning config

### DIFF
--- a/packages/core-esp32-s3.yaml
+++ b/packages/core-esp32-s3.yaml
@@ -6,8 +6,6 @@ esphome:
   project:
     name: $project_name
     version: $project_version
-  platformio_options:
-    board_build.flash_mode: dio
   
   on_boot:
     - priority: 800.0
@@ -21,6 +19,7 @@ esphome:
 
 esp32:
   board: esp32-s3-devkitc-1
+  flash_mode: dio
   framework:
     type: esp-idf
     version: recommended

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -1,8 +1,3 @@
-script:
-  - id: pc_warn
-    then:
-      - button.press: pre_close_warning
-
 secplus_gdo:
   id: cs_gdo
   input_gdo_pin: ${uart_rx_pin}
@@ -21,10 +16,9 @@ cover:
     id: gdo_door
     pre_close_warning_duration: $garage_door_close_warning_duration
     pre_close_warning_start:
-      - script.execute:
-          id: pc_warn
+      - button.press: pre_close_warning
     pre_close_warning_end:
-      - script.stop: pc_warn
+      - rtttl.stop
       - light.turn_off: warning_led
 
 sensor:

--- a/tests/test_secplus_gdo_yaml_format_strings.py
+++ b/tests/test_secplus_gdo_yaml_format_strings.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 SECPLUS_PACKAGE = Path("packages/secplus-gdo.yaml")
 SECPLUS_CONFIG = Path("circuitsetup-secplus-garage-door-opener.yaml")
+CORE_PACKAGE = Path("packages/core-esp32-s3.yaml")
 SECPLUS_INIT = Path("components/secplus_gdo/__init__.py")
 SECPLUS_COMPONENT = Path("components/secplus_gdo/secplus_gdo.cpp")
 GDO_DOOR_COMPONENT = Path("components/secplus_gdo/cover/gdo_door.cpp")
@@ -12,8 +13,23 @@ def test_secplus_config_owns_pinned_gdolib_release():
     component_source = SECPLUS_INIT.read_text(encoding="utf-8")
     config_source = SECPLUS_CONFIG.read_text(encoding="utf-8")
 
-    assert '"gdolib=https://github.com/CircuitSetup/gdolib#v1.2.0"' in config_source
+    assert '"gdolib=https://github.com/CircuitSetup/gdolib#v1.3.0"' in config_source
     assert "cg.add_library" not in component_source
+
+
+def test_core_package_uses_native_esp32_flash_mode():
+    source = CORE_PACKAGE.read_text(encoding="utf-8")
+
+    assert "  flash_mode: dio" in source
+    assert "board_build.flash_mode" not in source
+
+
+def test_pre_close_warning_can_be_stopped_directly():
+    source = SECPLUS_PACKAGE.read_text(encoding="utf-8")
+
+    assert "pc_warn" not in source
+    assert "      - button.press: pre_close_warning" in source
+    assert "      - rtttl.stop" in source
 
 
 def test_component_rejects_multiple_driver_instances():


### PR DESCRIPTION
## Summary
- configure DIO flash mode through ESPHome's native ESP32 schema
- remove the ineffective `pc_warn` wrapper
- stop the RTTTL warning immediately when a pending close is cancelled
- add regression coverage for both configuration changes

## Root cause
Native ESP-IDF ignores PlatformIO's `board_build.flash_mode` setting. The warning script also completed immediately after dispatching the button automation, so stopping that script could not stop the active warning tone.

## Validation
- `python -m pytest -q` (`12 passed`)
- ESPHome `2026.7.0` local-package configuration validation
- ESPHome `2026.7.0` full Security+ firmware compile
- generated SDK config contains `CONFIG_ESPTOOLPY_FLASHMODE_DIO=y`